### PR TITLE
Exchange Redux for new React Context(TM) API

### DIFF
--- a/src/authentication/components/Authenticate.tsx
+++ b/src/authentication/components/Authenticate.tsx
@@ -1,10 +1,11 @@
 import React, { Fragment } from 'react';
 import { IGroup } from 'core/models/Group';
 import { connect } from 'react-redux';
-import { IState } from '../reducers';
+//import { IState } from '../reducers';
 import { Permission } from 'core/models/Permission';
+import { UserContext } from '../providers/UserProvider';
 import { AuthUser } from '../models/User';
-
+/*
 export interface Props extends IState {
   user: AuthUser
   children: JSX.Element;
@@ -16,7 +17,7 @@ export const mapStateToProps = (state: IState): IState => {
   return { user: new AuthUser(state.user) };
 }
 
-export const mapDispatchToProps = (dispatch: Function) => ({/** Not going to change the state for user */})
+export const mapDispatchToProps = (dispatch: Function) => ({})
 
 const GroupAccess = ({ children, authentication, user, alt = null }: Props) => (
   <Fragment>
@@ -25,3 +26,22 @@ const GroupAccess = ({ children, authentication, user, alt = null }: Props) => (
 )
 
 export default connect(mapStateToProps, mapDispatchToProps)(GroupAccess)
+*/
+
+export interface IState {
+  children: JSX.Element;
+  alt?: JSX.Element;
+  authentication: IGroup | Permission;
+}
+
+const Authentcate = ({ children, authentication, alt = null }: IState) => (
+  <UserContext.Consumer>
+    { ({ user, loggedIn }) => {
+      console.log(loggedIn)
+      return user.hasPermission(authentication) ? children : alt }
+    }
+  </UserContext.Consumer>
+)
+
+export default Authentcate;
+

--- a/src/authentication/providers/UserProvider.tsx
+++ b/src/authentication/providers/UserProvider.tsx
@@ -1,0 +1,40 @@
+import React, { Component, createContext, Context } from 'react';
+import { AuthUser } from '../models/User';
+import { logIn } from '../api';
+import { initialState as IS } from '../reducers';
+
+export interface IState {
+  user: AuthUser;
+  loggedIn: boolean;
+}
+
+const initialState = {
+  user: new AuthUser(IS.user),
+  loggedIn: false
+}
+
+export const UserContext = createContext(initialState);
+
+class UserProvider extends Component<{}, IState> {
+  state: IState = initialState;
+
+  /**
+   * @summary Obviously more logic is needed here.
+   * @description try to log in via API, and set the state of the provider to logged in user.
+   */
+  async componentDidMount() {
+    const data = await logIn('anon', 'user');
+    const user = new AuthUser(data);
+    this.setState({ user, loggedIn: true });
+  }
+
+  render() {
+    return(
+      <UserContext.Provider value={this.state}>
+        { this.props.children }
+      </UserContext.Provider>
+    )
+  }
+}
+
+export default UserProvider;

--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -1,12 +1,27 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, ReactChild, ReactChildren } from 'react';
 import './less/core.less'
 import { Link } from 'react-router-dom';
 import { routes } from 'App';
 import Header from './components/Header/index';
 import Footer from './components/Footer/index';
+import UserProvider from 'authentication/providers/UserProvider';
 
-const Core = ({ children }: any) => (
-  <div>
+/*
+const Providers: ReactNode[] = [
+  UserProvider
+]
+
+const Provide = (nodes: ReactNode[]): ReactNode => {
+  return(
+    <>
+      { nodes.reduce((Accumulator, Node) => <Accumulator><Node /></Accumulator>) }
+    </>
+  )
+}
+*/
+
+const Core = ({ children }: { children: ReactChildren }) => (
+  <UserProvider>
     <Header />
     {/*% block submenu %}{% endblock %*/}
     {/*% if messages %*/}
@@ -14,7 +29,7 @@ const Core = ({ children }: any) => (
     { children }
     <div className="container" id="isloading-component"></div>
     <Footer />
-  </div>
+  </UserProvider>
 );
 
 export default Core;


### PR DESCRIPTION
React recently (April 2018) released React 16.3.
This includes an all new context API for providing data to components.

The usage of Redux in this project was fairly simple, and a quick glance at the new API proved that it wasn't really needed. At least not yet.

The usage of Redux was to provide the user to different components throughout the application without passing it as a prop everywhere. This can now be achieved fairly simply by using a context provider at the top level of the app. Then adding a context consumer where the user is needed.

Redux has as of now been commented out, while we figure out if this is a good solution or not. Feel free to add your thought, if you ever see this :smile: 