### PR TITLE
Implement parallell loading of events in the Image View

### DIFF
--- a/src/events/components/ImageView/index.tsx
+++ b/src/events/components/ImageView/index.tsx
@@ -48,14 +48,14 @@ class ImageView extends Component<IEventViewProps, IState> {
   };
 
   public componentDidMount() {
-    this.getEventsParallelle();
+    this.getEventsParallell();
   }
 
   public componentWillUnmount() {
     this.setState({ fetched: false });
   }
 
-  public async getEventsParallelle() {
+  public async getEventsParallell() {
     const left = this.getTypeEvents([EventTypeEnum.BEDPRES]);
     const middle = this.getTypeEvents([EventTypeEnum.KURS]);
     const right = this.getTypeEvents([
@@ -74,6 +74,7 @@ class ImageView extends Component<IEventViewProps, IState> {
     return await getEvents({
       event_end__gte: DateTime.local().toISODate(),
       event_type: types,
+      page_size: 4,
     });
   }
 


### PR DESCRIPTION
Title says most of it

- Use Promise.all() to fetch all event types at the same time.
- Also moved away from *snake_case* in favor of *camelCase*