### PR TITLE
Make profile statistics load all pages

### DIFF
--- a/src/common/components/Panes/Page.tsx
+++ b/src/common/components/Panes/Page.tsx
@@ -1,6 +1,16 @@
-import React, { Props } from 'react';
+import React, { ReactNode } from 'react';
+import Spinner from '../Spinner';
 import style from './profileCommon.less';
 
-export const Page = ({ children }: Props<any>) => <div className={style.page}>{children}</div>;
+export interface IProps {
+  children: ReactNode;
+  loading?: boolean;
+}
+
+export const Page = ({ children, loading }: IProps) => (
+  <div className={style.page}>
+    { loading ? <Spinner /> : children }
+  </div>
+);
 
 export default Page;

--- a/src/common/components/Panes/Page.tsx
+++ b/src/common/components/Panes/Page.tsx
@@ -8,9 +8,7 @@ export interface IProps {
 }
 
 export const Page = ({ children, loading }: IProps) => (
-  <div className={style.page}>
-    { loading ? <Spinner /> : children }
-  </div>
+  <div className={style.page}>{loading ? <Spinner /> : children}</div>
 );
 
 export default Page;

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -50,7 +50,11 @@ export const get = async (query: string, parameters: object = {}, options: Reque
  * @param query The API endpoint to fetch results from.
  * @param page An optional page to start fetching data on.
  */
-export async function getAllPages<T>(query: string, parameters: IBaseAPIParameters = {}, options: RequestInit = {}): Promise<T[]> {
+export async function getAllPages<T>(
+  query: string,
+  parameters: IBaseAPIParameters = {},
+  options: RequestInit = {}
+): Promise<T[]> {
   let data: IAPIData<T>;
   let results: T[] = [];
   let page = parameters.page || 1;
@@ -60,7 +64,7 @@ export async function getAllPages<T>(query: string, parameters: IBaseAPIParamete
     page += 1;
   } while (data.next);
   return results;
-};
+}
 
 /**
  * @summary Simple fetch-API wrapper for HTTP POST

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -50,16 +50,15 @@ export const get = async (query: string, parameters: object = {}, options: Reque
  * @param query The API endpoint to fetch results from.
  * @param page An optional page to start fetching data on.
  */
-export const getAllPages = async (query: string, page: number = 1): Promise<any> => {
-  let data: IAPIData<any>;
-  let results: any[] = [];
-
+export async function getAllPages<T>(query: string, parameters: IBaseAPIParameters = {}, options: RequestInit = {}): Promise<T[]> {
+  let data: IAPIData<T>;
+  let results: T[] = [];
+  let page = parameters.page || 1;
   do {
-    data = await get(query, { format: 'json', page });
+    data = await get(query, { ...parameters, page }, options);
     results = [...results, ...data.results];
     page += 1;
   } while (data.next);
-
   return results;
 };
 
@@ -86,21 +85,4 @@ export const post = async (
     })
   );
   return performRequest(request);
-};
-
-export const getAll = async (
-  query: string,
-  parameters: IBaseAPIParameters = {},
-  options: RequestInit = {},
-  page: number = 1
-): Promise<any> => {
-  parameters.page = page;
-  const data = await get(query, parameters, options);
-  const { next } = data;
-  let { result } = data;
-  if (next) {
-    result = [...result, ...(await getAll(query, parameters, options, next))];
-  }
-
-  return result || [];
 };

--- a/src/frontpage/api/offline.ts
+++ b/src/frontpage/api/offline.ts
@@ -8,5 +8,5 @@ export const getOfflines = async (page: number = 1): Promise<IAPIData<IOfflineIs
 };
 
 export const getRemaindingOfflines = (): Promise<IOfflineIssue[]> => {
-  return getAllPages(API_URL, 2);
+  return getAllPages<IOfflineIssue>(API_URL, { page: 2 });
 };

--- a/src/profile/api/orders.ts
+++ b/src/profile/api/orders.ts
@@ -1,10 +1,10 @@
 import { IAuthUser } from 'authentication/models/User';
-import { get, withUser } from 'common/utils/api';
+import { getAllPages, withUser } from 'common/utils/api';
 import { IOrderLine } from 'profile/models/Orders';
 
 const API_URL = '/api/v1/profile/orders';
 
 export const getOrders = async (user: IAuthUser): Promise<IOrderLine[]> => {
-  const { results } = await get(API_URL, { page_size: 80 }, withUser(user));
+  const results = await getAllPages<IOrderLine>(API_URL, { page_size: 80 }, withUser(user));
   return results;
 };

--- a/src/profile/components/Statistics/Orders/index.tsx
+++ b/src/profile/components/Statistics/Orders/index.tsx
@@ -47,7 +47,7 @@ class Orders extends Component<IProps, IState> {
     const totalItems = orders.reduce<number>((acc, order) => acc + order.quantity, 0);
     const totalCost = orders.reduce<number>((acc, order) => acc + Number(order.price), 0);
     return (
-      <Page>
+      <Page loading={orderLines.length === 0}>
         <Pane>
           <Markdown source={ABOUT_STATISTICS} />
         </Pane>


### PR DESCRIPTION
- Add option for loading spinner on a pane page
- Make `getAllPages` support all options from simple `get`.
- Remove additional `getAll` implementation that did not work.