### PR TITLE
changing timedate format in events to 24Hr

### DIFF
--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -50,9 +50,9 @@ const RuleBundles = ({ event }: IAttendanceEventProps) => {
 };
 
 const AttendanceEvent = ({ event }: IAttendanceEventProps) => {
-  const registrationStart = DateTime.fromISO(event.registration_start).toFormat('d MMM hh:mm');
-  const registrationEnd = DateTime.fromISO(event.registration_end).toFormat('d MMM hh:mm');
-  const cancellationDeadline = DateTime.fromISO(event.unattend_deadline).toFormat('d MMM hh:mm');
+  const registrationStart = DateTime.fromISO(event.registration_start).toFormat('d MMM t');
+  const registrationEnd = DateTime.fromISO(event.registration_end).toFormat('d MMM t');
+  const cancellationDeadline = DateTime.fromISO(event.unattend_deadline).toFormat('d MMM t');
 
   return (
     <div className={style.blockGrid}>

--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -50,9 +50,9 @@ const RuleBundles = ({ event }: IAttendanceEventProps) => {
 };
 
 const AttendanceEvent = ({ event }: IAttendanceEventProps) => {
-  const registrationStart = DateTime.fromISO(event.registration_start).toFormat('d MMM t');
-  const registrationEnd = DateTime.fromISO(event.registration_end).toFormat('d MMM t');
-  const cancellationDeadline = DateTime.fromISO(event.unattend_deadline).toFormat('d MMM t');
+  const registrationStart = DateTime.fromISO(event.registration_start).toFormat('d MMM HH:mm');
+  const registrationEnd = DateTime.fromISO(event.registration_end).toFormat('d MMM HH:mm');
+  const cancellationDeadline = DateTime.fromISO(event.unattend_deadline).toFormat('d MMM HH:mm');
 
   return (
     <div className={style.blockGrid}>

--- a/src/events/components/DetailView/PictureCard.tsx
+++ b/src/events/components/DetailView/PictureCard.tsx
@@ -11,10 +11,10 @@ const PictureCard = ({ image, event_start, event_end, location, company_event, e
   const imageUrl = eventImage ? eventImage.md : '';
   const color = getEventColor(event_type);
 
-  const startDate = DateTime.fromISO(event_start).toFormat('d MMM');
-  const startTime = DateTime.fromISO(event_start).toFormat('hh:mm');
+  const startDate = DateTime.fromISO(event_start).toFormat('d MMM ');
+  const startTime = DateTime.fromISO(event_start).toFormat('t');
   const endDate = DateTime.fromISO(event_end).toFormat('d MMM');
-  const endTime = DateTime.fromISO(event_end).toFormat('hh:mm');
+  const endTime = DateTime.fromISO(event_end).toFormat('t');
 
   return (
     <div className={style.pictureCard}>

--- a/src/events/components/DetailView/PictureCard.tsx
+++ b/src/events/components/DetailView/PictureCard.tsx
@@ -11,7 +11,7 @@ const PictureCard = ({ image, event_start, event_end, location, company_event, e
   const imageUrl = eventImage ? eventImage.md : '';
   const color = getEventColor(event_type);
 
-  const startDate = DateTime.fromISO(event_start).toFormat('d MMM ');
+  const startDate = DateTime.fromISO(event_start).toFormat('d MMM');
   const startTime = DateTime.fromISO(event_start).toFormat('t');
   const endDate = DateTime.fromISO(event_end).toFormat('d MMM');
   const endTime = DateTime.fromISO(event_end).toFormat('t');

--- a/src/events/components/DetailView/PictureCard.tsx
+++ b/src/events/components/DetailView/PictureCard.tsx
@@ -12,9 +12,9 @@ const PictureCard = ({ image, event_start, event_end, location, company_event, e
   const color = getEventColor(event_type);
 
   const startDate = DateTime.fromISO(event_start).toFormat('d MMM');
-  const startTime = DateTime.fromISO(event_start).toFormat('t');
+  const startTime = DateTime.fromISO(event_start).toFormat('HH:mm');
   const endDate = DateTime.fromISO(event_end).toFormat('d MMM');
-  const endTime = DateTime.fromISO(event_end).toFormat('t');
+  const endTime = DateTime.fromISO(event_end).toFormat('HH:mm');
 
   return (
     <div className={style.pictureCard}>


### PR DESCRIPTION
fulfilling issue #120 24 Hour format on events

Hopefully, this fix will work fine on any other computers. Would be great if someone could check if this is a universal fix on the problem or just a lucky coincidence due to my computer settings  or something

EDIT: i just followed https://moment.github.io/luxon/docs/manual/formatting.html#table-of-tokens for the toFormat() since it seems like its the correct manual

BEFORE:

![not24hr](https://user-images.githubusercontent.com/41551253/48925497-5ca33280-eec4-11e8-88b2-edfea26d9a79.png)

AFTER:

![24hrfix1](https://user-images.githubusercontent.com/41551253/48925457-fd452280-eec3-11e8-9679-008ad5470bcb.png)
![24hrfix2](https://user-images.githubusercontent.com/41551253/48925458-fd452280-eec3-11e8-9c08-e65227dd8237.png)
![24hrfix3](https://user-images.githubusercontent.com/41551253/48925468-22399580-eec4-11e8-8e14-acfaf9c590a3.png)
