### PR TITLE
Date time fix for careers

### DIFF
--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -6,6 +6,16 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import style from '../less/career.less';
 import { formatLocations } from './JobListItem';
+import { DateTime } from 'luxon';
+
+const formatDeadline = (deadline: any) => {
+  //Will return a formated date from ISO form if there's a deadline
+  if (deadline) {
+    return DateTime.fromISO(deadline).toFormat('d MMM y');
+  }
+  //No deadline is specified
+  return 'Ikke spesifisert';
+};
 
 const JobDetails = (props: ICareerOpportunity) => (
   <div>
@@ -27,7 +37,7 @@ const JobDetails = (props: ICareerOpportunity) => (
             <h3>Nøkkelinformasjon</h3>
             <p>Type: {props.employment.name}</p>
             <p>Sted: {formatLocations(props.location.map((loc) => loc.name))}</p>
-            <p>Frist: {props.deadline}</p>
+            <p>Frist: {formatDeadline(props.deadline)}</p>
           </div>
         </div>
       </div>

--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom';
 import style from '../less/career.less';
 import { formatLocations } from './JobListItem';
 
-const formatDeadline = (deadline: any) => {
+export const formatDeadline = (deadline: any) => {
   // Will return a formated date from ISO form if there's a deadline
   if (deadline) {
     return DateTime.fromISO(deadline).toFormat('d MMM y');

--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -8,12 +8,14 @@ import { Link } from 'react-router-dom';
 import style from '../less/career.less';
 import { formatLocations } from './JobListItem';
 
-export const formatDeadline = (deadline: any) => {
-  // Will return a formated date from ISO form if there's a deadline
+/**
+ * @summary formats the deadline from ISO format to Date Month Year
+ * @return the formated deadline as a string or the string "Ikke spesifisert" if deadline is null
+ */
+export const formatDeadline = (deadline: string): string => {
   if (deadline) {
     return DateTime.fromISO(deadline).toFormat('d MMM y');
   }
-  // No deadline is specified
   return 'Ikke spesifisert';
 };
 

--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -2,18 +2,18 @@ import { ICareerOpportunity } from 'career/models/Career';
 import Heading from 'common/components/Heading';
 import Img from 'common/components/Img';
 import Markdown from 'common/components/Markdown';
+import { DateTime } from 'luxon';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import style from '../less/career.less';
 import { formatLocations } from './JobListItem';
-import { DateTime } from 'luxon';
 
 const formatDeadline = (deadline: any) => {
-  //Will return a formated date from ISO form if there's a deadline
+  // Will return a formated date from ISO form if there's a deadline
   if (deadline) {
     return DateTime.fromISO(deadline).toFormat('d MMM y');
   }
-  //No deadline is specified
+  // No deadline is specified
   return 'Ikke spesifisert';
 };
 

--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -50,9 +50,9 @@ const RuleBundles = ({ event }: IAttendanceEventProps) => {
 };
 
 const AttendanceEvent = ({ event }: IAttendanceEventProps) => {
-  const registrationStart = DateTime.fromISO(event.registration_start).toFormat('d MMM hh:mm');
-  const registrationEnd = DateTime.fromISO(event.registration_end).toFormat('d MMM hh:mm');
-  const cancellationDeadline = DateTime.fromISO(event.unattend_deadline).toFormat('d MMM hh:mm');
+  const registrationStart = DateTime.fromISO(event.registration_start).toFormat('d MMM t');
+  const registrationEnd = DateTime.fromISO(event.registration_end).toFormat('d MMM t');
+  const cancellationDeadline = DateTime.fromISO(event.unattend_deadline).toFormat('d MMM t');
 
   return (
     <div className={style.blockGrid}>

--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -50,9 +50,9 @@ const RuleBundles = ({ event }: IAttendanceEventProps) => {
 };
 
 const AttendanceEvent = ({ event }: IAttendanceEventProps) => {
-  const registrationStart = DateTime.fromISO(event.registration_start).toFormat('d MMM t');
-  const registrationEnd = DateTime.fromISO(event.registration_end).toFormat('d MMM t');
-  const cancellationDeadline = DateTime.fromISO(event.unattend_deadline).toFormat('d MMM t');
+  const registrationStart = DateTime.fromISO(event.registration_start).toFormat('d MMM HH:mm');
+  const registrationEnd = DateTime.fromISO(event.registration_end).toFormat('d MMM HH:mm');
+  const cancellationDeadline = DateTime.fromISO(event.unattend_deadline).toFormat('d MMM HH:mm');
 
   return (
     <div className={style.blockGrid}>

--- a/src/events/components/DetailView/PictureCard.tsx
+++ b/src/events/components/DetailView/PictureCard.tsx
@@ -11,10 +11,10 @@ const PictureCard = ({ image, event_start, event_end, location, company_event, e
   const imageUrl = eventImage ? eventImage.md : '';
   const color = getEventColor(event_type);
 
-  const startDate = DateTime.fromISO(event_start).toFormat('d MMM');
-  const startTime = DateTime.fromISO(event_start).toFormat('hh:mm');
+  const startDate = DateTime.fromISO(event_start).toFormat('d MMM ');
+  const startTime = DateTime.fromISO(event_start).toFormat('t');
   const endDate = DateTime.fromISO(event_end).toFormat('d MMM');
-  const endTime = DateTime.fromISO(event_end).toFormat('hh:mm');
+  const endTime = DateTime.fromISO(event_end).toFormat('t');
 
   return (
     <div className={style.pictureCard}>

--- a/src/events/components/DetailView/PictureCard.tsx
+++ b/src/events/components/DetailView/PictureCard.tsx
@@ -11,7 +11,7 @@ const PictureCard = ({ image, event_start, event_end, location, company_event, e
   const imageUrl = eventImage ? eventImage.md : '';
   const color = getEventColor(event_type);
 
-  const startDate = DateTime.fromISO(event_start).toFormat('d MMM ');
+  const startDate = DateTime.fromISO(event_start).toFormat('d MMM');
   const startTime = DateTime.fromISO(event_start).toFormat('t');
   const endDate = DateTime.fromISO(event_end).toFormat('d MMM');
   const endTime = DateTime.fromISO(event_end).toFormat('t');

--- a/src/events/components/DetailView/PictureCard.tsx
+++ b/src/events/components/DetailView/PictureCard.tsx
@@ -12,9 +12,9 @@ const PictureCard = ({ image, event_start, event_end, location, company_event, e
   const color = getEventColor(event_type);
 
   const startDate = DateTime.fromISO(event_start).toFormat('d MMM');
-  const startTime = DateTime.fromISO(event_start).toFormat('t');
+  const startTime = DateTime.fromISO(event_start).toFormat('HH:mm');
   const endDate = DateTime.fromISO(event_end).toFormat('d MMM');
-  const endTime = DateTime.fromISO(event_end).toFormat('t');
+  const endTime = DateTime.fromISO(event_end).toFormat('HH:mm');
 
   return (
     <div className={style.pictureCard}>


### PR DESCRIPTION
wello, i made a small function to convert ISO strings into day, month year(d MMM y) specifically for. I just guessed this is the correct format since it was used in onlineweb4. 

referencing to #123
could do some changes or move the function if wished to probably 

Heres some pics:
BEFORE:
![ikkespesifisert](https://user-images.githubusercontent.com/41551253/48941347-889dd280-ef1b-11e8-9245-a75c728ab0cf.png)
![currenttimeformat](https://user-images.githubusercontent.com/41551253/48941349-89366900-ef1b-11e8-8d5a-069cc1f46701.png)

AFTER:
![ikkespesifisertafter](https://user-images.githubusercontent.com/41551253/48941348-89366900-ef1b-11e8-90af-82045ac83cb2.png)
![afterfixformat](https://user-images.githubusercontent.com/41551253/48941351-89ceff80-ef1b-11e8-8fe8-578ef28bd7f2.png)
