### PR TITLE
fixing 1 card view in career thingies

### DIFF
--- a/src/career/less/career.less
+++ b/src/career/less/career.less
@@ -75,7 +75,7 @@
 
 .jobList {
   display: grid;
-  grid-template-rows: 1fr;
+  grid-template-rows: 1fr 1fr 1fr 1fr;
   grid-gap: 20px;
   grid-area: jobs;
 }

--- a/src/career/less/career.less
+++ b/src/career/less/career.less
@@ -75,7 +75,7 @@
 
 .jobList {
   display: grid;
-  grid-template-rows: 1fr 1fr 1fr 1fr;
+  grid-template-rows: repeat(4, min-content);
   grid-gap: 20px;
   grid-area: jobs;
 }


### PR DESCRIPTION
#121  
Fixing the issue where if there's only 1 card left after filtering it will display the whole page.

<--- BEFORE                          AFTER --->
![singlecard](https://user-images.githubusercontent.com/41551253/48955521-9f115180-ef4e-11e8-9fa6-ed1e0af555e0.png)
![twocards](https://user-images.githubusercontent.com/41551253/48955522-9f115180-ef4e-11e8-9430-e9b31d3577e7.png)
4 Cards looking as normal
![4cards](https://user-images.githubusercontent.com/41551253/48955523-9f115180-ef4e-11e8-9b17-433799f04603.png)
