### PR TITLE
Change the display for no issues in repo on contribution to display as '0', not '??', make the number of issues bold

### DIFF
--- a/src/contribution/components/Repository.tsx
+++ b/src/contribution/components/Repository.tsx
@@ -12,7 +12,7 @@ const Repository = ({ id, name, description, public_url, languages, issues }: IR
           <p>{description}</p>
         </div>
         <div className={style.issues}>
-          <h2>{issues ? issues : '??'}</h2>
+          <h2>{issues ? issues : '0'}</h2>
           <h2>Issues</h2>
         </div>
       </div>

--- a/src/contribution/less/contribution.less
+++ b/src/contribution/less/contribution.less
@@ -60,7 +60,7 @@
   height: 80px;
   border: @gray solid 1px;
   border-radius: 50%;
-  
+
   & > h2:first-child {
     font-weight: bold;
   }

--- a/src/contribution/less/contribution.less
+++ b/src/contribution/less/contribution.less
@@ -85,3 +85,7 @@
     display: block;
   }
 }
+
+.issues > h2:first-child {
+  font-weight: bold;
+}

--- a/src/contribution/less/contribution.less
+++ b/src/contribution/less/contribution.less
@@ -60,6 +60,10 @@
   height: 80px;
   border: @gray solid 1px;
   border-radius: 50%;
+  
+  & > h2:first-child {
+    font-weight: bold;
+  }
 }
 
 .languageBar {
@@ -84,8 +88,4 @@
   &.active {
     display: block;
   }
-}
-
-.issues > h2:first-child {
-  font-weight: bold;
 }


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Change the display for no issues in repo on /contribution to display as '0', not '??', it looks better.
Also made the issue number bold

## Screenshot(s) if appropriate
AFTER: 
<img width="1208" alt="skjermbilde 2018-11-24 kl 12 36 34" src="https://user-images.githubusercontent.com/36937807/48967744-a9caf580-efe5-11e8-83d4-c7e591de3761.png">

BEFORE:
<img width="1208" alt="skjermbilde 2018-11-24 kl 12 36 37" src="https://user-images.githubusercontent.com/36937807/48967746-ae8fa980-efe5-11e8-88fb-50803da7dc51.png">


<!-- provide screenshots (before and after) if doing design changes -->