### PR TITLE
creating a imageView event version for lower screen widths

### DIFF
--- a/src/events/components/ImageView/image.less
+++ b/src/events/components/ImageView/image.less
@@ -4,7 +4,8 @@
 @edge-height: 20px;
 
 .largeEventGrid,
-.smallEventGrid {
+.smallEventGrid,
+.smallerWidthGrid {
   display: grid;
   grid-template-columns: 1fr;
   grid-gap: 20px;
@@ -23,6 +24,15 @@
 }
 
 @media (min-width: 1024px) {
+  .largeEventGrid,
+  .smallEventGrid {
+    display: grid;
+  }
+
+  .smallerWidthGrid {
+    display: none;
+  }
+
   .largeEventGrid {
     grid-template-columns: 1fr 1fr 1fr;
   }
@@ -31,6 +41,17 @@
     grid-auto-flow: column;
     grid-template-rows: 1fr 1fr 1fr;
     grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+@media (max-width: 1023px) {
+  .smallerWidthGrid {
+    display: grid;
+  }
+
+  .largeEventGrid,
+  .smallEventGrid {
+    display: none;
   }
 }
 

--- a/src/events/components/ImageView/image.less
+++ b/src/events/components/ImageView/image.less
@@ -54,7 +54,7 @@
     display: none;
   }
 
-  .smallerWidthGrid a:nth-child(4),
+  .smallerWidthGrid > a:nth-child(4),
   :nth-child(8) {
     margin-bottom: 20px;
   }

--- a/src/events/components/ImageView/image.less
+++ b/src/events/components/ImageView/image.less
@@ -53,6 +53,11 @@
   .smallEventGrid {
     display: none;
   }
+
+  .smallerWidthGrid a:nth-child(4),
+  :nth-child(8) {
+    margin-bottom: 20px;
+  }
 }
 
 .large {

--- a/src/events/components/ImageView/index.tsx
+++ b/src/events/components/ImageView/index.tsx
@@ -35,6 +35,15 @@ class ImageView extends Component<IProps> {
           <SmallEventColumn events={eventsMiddle.slice(1, 4)} />
           <SmallEventColumn events={eventsRight.slice(1, 4)} />
         </div>
+
+        <div className={style.smallerWidthGrid}>
+          {eventsLeft[0] ? <LargeEvent {...eventsLeft[0]} /> : <LargeEventPlaceholder event_type={2} />}
+          <SmallEventColumn events={eventsLeft.slice(1, 4)} />
+          {eventsMiddle[0] ? <LargeEvent {...eventsMiddle[0]} /> : <LargeEventPlaceholder event_type={3} />}
+          <SmallEventColumn events={eventsMiddle.slice(1, 4)} />
+          {eventsRight[0] ? <LargeEvent {...eventsRight[0]} /> : <LargeEventPlaceholder event_type={1} />}
+          <SmallEventColumn events={eventsRight.slice(1, 4)} />
+        </div>
       </>
     );
   }


### PR DESCRIPTION
Fixing issue #60.

I mean this does solve the issue, not sure if this is a fine way of solving this issue or if its a better way. Maybe just take a look and give some feedback. This will trigger if the width is lower than 1024px

BEFORE, AFTER:
![widthfix](https://user-images.githubusercontent.com/41551253/48961111-61bebb00-ef72-11e8-93cd-61e8f223b25d.png)

Doesnt break the normal view:
![normalwidth](https://user-images.githubusercontent.com/41551253/48961075-2b813b80-ef72-11e8-813c-40ec12e8eeb0.png)



