### PR TITLE
Fix #142 - Missing spaces after links

### DIFF
--- a/src/hobbygroups/components/Intro.tsx
+++ b/src/hobbygroups/components/Intro.tsx
@@ -11,9 +11,11 @@ const Intro = () => (
     </p>
     <h2>Hvordan søke om støtte til din interessegruppe?</h2>
     <p>
-      Du kan søke om økonomisk støtte til din interessegruppe ved å sende en mail til <a href="mailto:seniorkom@online.ntnu.no">seniorkom@online.ntnu.no</a>
+      Du kan søke om økonomisk støtte til din interessegruppe ved å sende en mail til{' '}
+      <a href="mailto:seniorkom@online.ntnu.no">seniorkom@online.ntnu.no</a>
       <br />
-      Mer informasjon om hvordan dette gjøres finnes <a href="https://online.ntnu.no/wiki/online/info/innsikt-og-interface/interessegrupper/">her</a>.
+      Mer informasjon om hvordan dette gjøres finnes{' '}
+      <a href="https://online.ntnu.no/wiki/online/info/innsikt-og-interface/interessegrupper/">her</a>.
     </p>
   </div>
 );

--- a/src/hobbygroups/components/Intro.tsx
+++ b/src/hobbygroups/components/Intro.tsx
@@ -11,11 +11,9 @@ const Intro = () => (
     </p>
     <h2>Hvordan søke om støtte til din interessegruppe?</h2>
     <p>
-      Du kan søke om økonomisk støtte til din interessegruppe ved å sende en mail til
-      <a href="mailto:seniorkom@online.ntnu.no">seniorkom@online.ntnu.no</a>
+      Du kan søke om økonomisk støtte til din interessegruppe ved å sende en mail til <a href="mailto:seniorkom@online.ntnu.no">seniorkom@online.ntnu.no</a>
       <br />
-      Mer informasjon om hvordan dette gjøres finnes
-      <a href="https://online.ntnu.no/wiki/online/info/innsikt-og-interface/interessegrupper/">her</a>.
+      Mer informasjon om hvordan dette gjøres finnes <a href="https://online.ntnu.no/wiki/online/info/innsikt-og-interface/interessegrupper/">her</a>.
     </p>
   </div>
 );

--- a/src/hobbygroups/components/Intro.tsx
+++ b/src/hobbygroups/components/Intro.tsx
@@ -1,22 +1,24 @@
+import Markdown from 'common/components/Markdown';
 import React from 'react';
 import style from '../less/hobbygroups.less';
 
+const introText = `
+  På denne siden finner du informasjon om alle de forskjellige interessegruppene i online. Ser du noe som ser
+  interessant ut? Ta kontakt og møt noen med samme interesser som deg. Interessegruppene i Online er grupper for
+  alle mulige slags interesser. Har du og en kompis eller to en sær/stilig/fantastisk interesse? Opprett en
+  interessegruppe!
+
+  ## Hvordan søke om støtte til din interessegruppe?
+
+  Du kan søke om økonomisk støtte til din interessegruppe ved å sende en mail til <seniorkom@online.ntnu.no>
+
+  Mer informasjon om hvordan dette gjøres finnes
+  [her](https://online.ntnu.no/wiki/online/info/innsikt-og-interface/interessegrupper/).
+`;
+
 const Intro = () => (
   <div className={style.intro}>
-    <p>
-      På denne siden finner du informasjon om alle de forskjellige interessegruppene i online. Ser du noe som ser
-      interessant ut? Ta kontakt og møt noen med samme interesser som deg. Interessegruppene i Online er grupper for
-      alle mulige slags interesser. Har du og en kompis eller to en sær/stilig/fantastisk interesse? Opprett en
-      interessegruppe!
-    </p>
-    <h2>Hvordan søke om støtte til din interessegruppe?</h2>
-    <p>
-      Du kan søke om økonomisk støtte til din interessegruppe ved å sende en mail til{' '}
-      <a href="mailto:seniorkom@online.ntnu.no">seniorkom@online.ntnu.no</a>
-      <br />
-      Mer informasjon om hvordan dette gjøres finnes{' '}
-      <a href="https://online.ntnu.no/wiki/online/info/innsikt-og-interface/interessegrupper/">her</a>.
-    </p>
+    <Markdown source={introText} />
   </div>
 );
 


### PR DESCRIPTION
AFTER:
![image](https://user-images.githubusercontent.com/36937807/48968425-ed2a6180-efef-11e8-9fad-69fb64fe0da9.png)
BEFORE:
![image](https://user-images.githubusercontent.com/36937807/48968429-f3204280-efef-11e8-95ae-5c4c0053b6d5.png)
