### PR TITLE
Add functionality to require login for specific routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import Loadable from 'react-loadable';
-import { Route, Router, Switch } from 'react-router-dom';
+import { Router, Switch } from 'react-router-dom';
 
 import AuthCallback from 'authentication/components/AuthCallback';
 import AuthProvider from 'authentication/providers/UserProvider';
@@ -11,6 +11,7 @@ import Career from './career/';
 import Contribution from './contribution';
 import Core from './core';
 import HttpError from './core/components/errors/HttpError';
+import Route from './core/components/Route';
 import Frontpage from './frontpage';
 import Hobbys from './hobbygroups';
 import Resources from './resources';
@@ -49,7 +50,7 @@ export const App = () => {
             <Route path={routes.contribution} component={Contribution} />
             <Route path={routes.hobbygroups} component={Hobbys} />
             <Route path={routes.resources} component={Resources} />
-            <Route path={routes.profile} component={LoadableProfile} />
+            <Route path={routes.profile} component={LoadableProfile} requireLogin />
             <Route path={routes.authCallback} component={AuthCallback} />
             <Route path="*" render={() => <HttpError code={404} />} />
           </Switch>

--- a/src/authentication/components/PrivateRoute.tsx
+++ b/src/authentication/components/PrivateRoute.tsx
@@ -1,0 +1,21 @@
+import HttpError from 'core/components/errors/HttpError';
+import React, { Component } from 'react';
+import { Route, RouteProps } from 'react-router-dom';
+import { IUserContext, UserContext } from '../providers/UserProvider';
+
+const NotLoggedIn = () => (
+  <HttpError code={401}  text="Du må være logget inn for å få tilgang til denne siden." /> 
+);
+
+class PrivateRoute extends Component<RouteProps> {
+  public static contextType = UserContext;
+  
+  public render() {
+    const { user }: IUserContext = this.context;
+    const { component, ...rest } = this.props
+    const view = user ? component : NotLoggedIn;
+    return <Route {...rest} component={view} />
+  }
+}
+
+export default PrivateRoute;

--- a/src/authentication/components/PrivateRoute.tsx
+++ b/src/authentication/components/PrivateRoute.tsx
@@ -3,18 +3,16 @@ import React, { Component } from 'react';
 import { Route, RouteProps } from 'react-router-dom';
 import { IUserContext, UserContext } from '../providers/UserProvider';
 
-const NotLoggedIn = () => (
-  <HttpError code={401}  text="Du må være logget inn for å få tilgang til denne siden." /> 
-);
+const NotLoggedIn = () => <HttpError code={401} text="Du må være logget inn for å få tilgang til denne siden." />;
 
 class PrivateRoute extends Component<RouteProps> {
   public static contextType = UserContext;
-  
+
   public render() {
     const { user }: IUserContext = this.context;
-    const { component, ...rest } = this.props
+    const { component, ...rest } = this.props;
     const view = user ? component : NotLoggedIn;
-    return <Route {...rest} component={view} />
+    return <Route {...rest} component={view} />;
   }
 }
 

--- a/src/career/containers/Career.tsx
+++ b/src/career/containers/Career.tsx
@@ -1,6 +1,7 @@
 import CareerOpportunities from 'career/providers/CareerProvider';
+import Route from 'core/components/Route';
 import React from 'react';
-import { Route, Switch } from 'react-router';
+import { Switch } from 'react-router';
 import DetailView from './DetailView';
 import FilterableJobList from './FilterableJobList';
 

--- a/src/core/components/Route.tsx
+++ b/src/core/components/Route.tsx
@@ -1,0 +1,13 @@
+import PrivateRoute from 'authentication/components/PrivateRoute';
+import React from 'react';
+import { Route as DefaultRoute, RouteProps } from 'react-router-dom';
+
+export interface IProps extends RouteProps {
+  requireLogin?: boolean;
+}
+
+const Route = ({ requireLogin, ...props }: IProps) => {
+  return requireLogin ? <PrivateRoute {...props} /> : <DefaultRoute {...props} />
+};
+
+export default Route;

--- a/src/core/components/Route.tsx
+++ b/src/core/components/Route.tsx
@@ -7,7 +7,7 @@ export interface IProps extends RouteProps {
 }
 
 const Route = ({ requireLogin, ...props }: IProps) => {
-  return requireLogin ? <PrivateRoute {...props} /> : <DefaultRoute {...props} />
+  return requireLogin ? <PrivateRoute {...props} /> : <DefaultRoute {...props} />;
 };
 
 export default Route;

--- a/src/events/components/EventsRouter.tsx
+++ b/src/events/components/EventsRouter.tsx
@@ -1,6 +1,7 @@
 import HttpError from 'core/components/errors/HttpError';
+import Route from 'core/components/Route';
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
 import DetailView from './DetailView';
 import EventsContainer from './EventsContainer';
 

--- a/src/profile/components/Settings/index.tsx
+++ b/src/profile/components/Settings/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Route, RouteProps, Switch } from 'react-router-dom';
+import { RouteProps, Switch } from 'react-router-dom';
 
 import HttpError from 'core/components/errors/HttpError';
+import Route from 'core/components/Route';
 import { IProfileProps } from 'profile';
 import AccessCard from './AccessCard';
 import Mails from './Mails';

--- a/src/profile/components/Statistics/index.tsx
+++ b/src/profile/components/Statistics/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Route, RouteProps, Switch } from 'react-router-dom';
+import { RouteProps, Switch } from 'react-router-dom';
 
 import HttpError from 'core/components/errors/HttpError';
+import Route from 'core/components/Route';
 import Orders from './Orders';
 
 const BASE_ROUTE = '/profile/statistics';

--- a/src/profile/index.tsx
+++ b/src/profile/index.tsx
@@ -1,9 +1,10 @@
 import HttpError from 'core/components/errors/HttpError';
+import Route from 'core/components/Route';
 import { History } from 'history';
 import 'multirange';
 import qs from 'query-string';
 import React from 'react';
-import { Route, RouteProps, Switch } from 'react-router-dom';
+import { RouteProps, Switch } from 'react-router-dom';
 import MainMenu from './components/MainMenu';
 import MyProfile from './components/Profile';
 import Search from './components/Search';


### PR DESCRIPTION
This creates a wrapper for the standard route implementation in React Router.
It will render a regular Route if nothing is specified, but if the `requireLogin` attribute is used on the route, the user will be consumed from its context and used to see if the client is logged in, the render the appropriate route.

Resolves most of #152 