### PR TITLE
Add link blocking with authentication

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import Career from './career/';
 import Contribution from './contribution';
 import Core from './core';
 import HttpError from './core/components/errors/HttpError';
-import Route from './core/components/Route';
+import { Route } from './core/components/Router';
 import Frontpage from './frontpage';
 import Hobbys from './hobbygroups';
 import Resources from './resources';

--- a/src/authentication/components/PrivateLink.tsx
+++ b/src/authentication/components/PrivateLink.tsx
@@ -1,0 +1,22 @@
+import classnames from 'classnames';
+import React, { Component } from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { IUserContext, UserContext } from '../providers/UserProvider';
+import style from './link.less';
+
+class PrivateLink extends Component<LinkProps> {
+  public static contextType = UserContext;
+
+  public render() {
+    const { user }: IUserContext = this.context;
+    const { className, to, ...props } = this.props;
+    if (user) {
+      return <Link {...this.props} />;
+    } else {
+      const currentClasses = className ? className.split(' ') : [];
+      return <Link {...props} className={classnames(currentClasses, style.link)} to="#" />;
+    }
+  }
+}
+
+export default PrivateLink;

--- a/src/authentication/components/RequireAuth.tsx
+++ b/src/authentication/components/RequireAuth.tsx
@@ -1,0 +1,22 @@
+import { Component } from 'react';
+import { IUserContext, UserContext } from '../providers/UserProvider';
+
+export interface IProps {
+  permissions?: string[];
+}
+
+/**
+ * @summary Require authentication and authorization to render children.
+ * @param {?string[]} permissions If specified, requires a set of permissions to render as well.
+ */
+class RequireAuth extends Component<IProps> {
+  public static contextType = UserContext;
+
+  public render() {
+    const { user }: IUserContext = this.context;
+    const { children } = this.props;
+    return user ? children : null;
+  }
+}
+
+export default RequireAuth;

--- a/src/authentication/components/link.less
+++ b/src/authentication/components/link.less
@@ -1,0 +1,4 @@
+.link {
+  pointer-events: none;
+  filter: brightness(70%);
+}

--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -2,9 +2,9 @@ import { ICareerOpportunity } from 'career/models/Career';
 import Heading from 'common/components/Heading';
 import Img from 'common/components/Img';
 import Markdown from 'common/components/Markdown';
+import { Link } from 'core/components/Router';
 import { DateTime } from 'luxon';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import style from '../less/career.less';
 import { formatLocations } from './JobListItem';
 

--- a/src/career/components/JobListItem.tsx
+++ b/src/career/components/JobListItem.tsx
@@ -1,7 +1,7 @@
 import { ICareerOpportunity } from 'career/models/Career';
 import Img from 'common/components/Img';
+import { Link } from 'core/components/Router';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import style from '../less/career.less';
 import { formatDeadline } from './JobDetails';
 

--- a/src/career/containers/Career.tsx
+++ b/src/career/containers/Career.tsx
@@ -1,5 +1,5 @@
 import CareerOpportunities from 'career/providers/CareerProvider';
-import Route from 'core/components/Route';
+import { Route } from 'core/components/Router';
 import React from 'react';
 import { Switch } from 'react-router';
 import DetailView from './DetailView';

--- a/src/core/components/Header/HeaderLogo.tsx
+++ b/src/core/components/Header/HeaderLogo.tsx
@@ -1,7 +1,7 @@
 import { routes } from 'App';
 import { STATIC_URL } from 'common/constants/endpoints';
+import { Link } from 'core/components/Router';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import style from './header.less';
 
 export interface IProps {

--- a/src/core/components/Header/Login.tsx
+++ b/src/core/components/Header/Login.tsx
@@ -2,8 +2,8 @@ import { routes } from 'App';
 import LoginView from 'authentication/components/Login';
 import { IAuthUser } from 'authentication/models/User';
 import { IUserContext, UserContext } from 'authentication/providers/UserProvider';
+import { Link } from 'core/components/Router';
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 import style from './header.less';
 
 export interface IState {

--- a/src/core/components/Header/index.tsx
+++ b/src/core/components/Header/index.tsx
@@ -48,7 +48,9 @@ class Header extends Component<IProps, IState> {
             className={classnames(style.links, { [style.dropdownMode]: this.state.isOpen })}
             onClick={this.closeMenu}
           >
-            <Link to={routes.profile} requireLogin>Profil</Link>
+            <Link to={routes.profile} requireLogin>
+              Profil
+            </Link>
             <Link to={routes.events}>Arkiv</Link>
             <Link to={routes.career}>Karriere</Link>
             <Link to={routes.resources}>Ressurser</Link>

--- a/src/core/components/Header/index.tsx
+++ b/src/core/components/Header/index.tsx
@@ -1,7 +1,7 @@
 import { routes } from 'App';
 import classnames from 'classnames';
+import { Link } from 'core/components/Router';
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 import style from './header.less';
 import HeaderLogo from './HeaderLogo';
 import HeaderLogin from './Login';
@@ -48,7 +48,7 @@ class Header extends Component<IProps, IState> {
             className={classnames(style.links, { [style.dropdownMode]: this.state.isOpen })}
             onClick={this.closeMenu}
           >
-            <Link to={routes.profile}>Profil</Link>
+            <Link to={routes.profile} requireLogin>Profil</Link>
             <Link to={routes.events}>Arkiv</Link>
             <Link to={routes.career}>Karriere</Link>
             <Link to={routes.resources}>Ressurser</Link>

--- a/src/core/components/Router/Link.tsx
+++ b/src/core/components/Router/Link.tsx
@@ -1,0 +1,11 @@
+import PrivateLink from 'authentication/components/PrivateLink';
+import React from 'react';
+import { Link as DefaultLink, LinkProps } from 'react-router-dom';
+
+export interface ILinkProps extends LinkProps {
+  requireLogin?: boolean;
+}
+
+export const Link = ({ requireLogin, ...props }: ILinkProps) => {
+  return requireLogin ? <PrivateLink {...props} /> : <DefaultLink {...props} />
+};

--- a/src/core/components/Router/Link.tsx
+++ b/src/core/components/Router/Link.tsx
@@ -7,5 +7,5 @@ export interface ILinkProps extends LinkProps {
 }
 
 export const Link = ({ requireLogin, ...props }: ILinkProps) => {
-  return requireLogin ? <PrivateLink {...props} /> : <DefaultLink {...props} />
+  return requireLogin ? <PrivateLink {...props} /> : <DefaultLink {...props} />;
 };

--- a/src/core/components/Router/Route.tsx
+++ b/src/core/components/Router/Route.tsx
@@ -2,12 +2,10 @@ import PrivateRoute from 'authentication/components/PrivateRoute';
 import React from 'react';
 import { Route as DefaultRoute, RouteProps } from 'react-router-dom';
 
-export interface IProps extends RouteProps {
+export interface IRouteProps extends RouteProps {
   requireLogin?: boolean;
 }
 
-const Route = ({ requireLogin, ...props }: IProps) => {
+export const Route = ({ requireLogin, ...props }: IRouteProps) => {
   return requireLogin ? <PrivateRoute {...props} /> : <DefaultRoute {...props} />;
 };
-
-export default Route;

--- a/src/core/components/Router/index.ts
+++ b/src/core/components/Router/index.ts
@@ -1,0 +1,1 @@
+export * from './Route';

--- a/src/core/components/Router/index.ts
+++ b/src/core/components/Router/index.ts
@@ -1,1 +1,2 @@
 export * from './Route';
+export * from './Link';

--- a/src/events/components/CalendarView/CalendarTile.tsx
+++ b/src/events/components/CalendarView/CalendarTile.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
+import { Link } from 'core/components/Router';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { getEventColor, INewEvent } from '../../models/Event';
 import style from './calendar.less';
 

--- a/src/events/components/EventsRouter.tsx
+++ b/src/events/components/EventsRouter.tsx
@@ -1,5 +1,5 @@
 import HttpError from 'core/components/errors/HttpError';
-import Route from 'core/components/Route';
+import { Route } from 'core/components/Router';
 import React from 'react';
 import { Switch } from 'react-router-dom';
 import DetailView from './DetailView';

--- a/src/events/components/ImageView/LargeEvent.tsx
+++ b/src/events/components/ImageView/LargeEvent.tsx
@@ -1,10 +1,10 @@
 import { DOMAIN } from 'common/constants/endpoints';
 import IImage from 'common/models/Image';
+import { Link } from 'core/components/Router';
 import { getEventColor, getEventType, ICompanyEvent, INewEvent } from 'events/models/Event';
 import { getEventAttendees } from 'events/utils/attendee';
 import { DateTime } from 'luxon';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import style from './image.less';
 
 const getEventImage = (image: IImage | null, company_event: ICompanyEvent[]) => {

--- a/src/events/components/ImageView/SmallEvent.tsx
+++ b/src/events/components/ImageView/SmallEvent.tsx
@@ -1,8 +1,8 @@
+import { Link } from 'core/components/Router';
 import { getEventColor, INewEvent } from 'events/models/Event';
 import { getEventAttendees } from 'events/utils/attendee';
 import { DateTime } from 'luxon';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import style from './image.less';
 
 const SmallEvent = ({ title, event_type, event_start, attendance_event, id }: INewEvent) => (

--- a/src/events/components/ListView/index.tsx
+++ b/src/events/components/ListView/index.tsx
@@ -1,6 +1,6 @@
+import { Link } from 'core/components/Router';
 import { IListEventsState, ListEventsContext } from 'events/providers/ListEvents';
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 import { IEventViewProps } from '../../models/Event';
 import style from './list.less';
 import ListEvent from './ListEvent';

--- a/src/profile/components/MainMenu.tsx
+++ b/src/profile/components/MainMenu.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
+import { Link } from 'core/components/Router';
 import React, { Component } from 'react';
-import Router, { Link } from 'react-router-dom';
+import Router from 'react-router-dom';
 import { routes } from '../index';
 import style from './mainMenu.less';
 

--- a/src/profile/components/Settings/Menu/Tab.tsx
+++ b/src/profile/components/Settings/Menu/Tab.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
+import { Link } from 'core/components/Router';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import style from './menu.less';
 
 export interface IProps {

--- a/src/profile/components/Settings/index.tsx
+++ b/src/profile/components/Settings/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { RouteProps, Switch } from 'react-router-dom';
 
 import HttpError from 'core/components/errors/HttpError';
-import Route from 'core/components/Route';
+import { Route } from 'core/components/Router';
 import { IProfileProps } from 'profile';
 import AccessCard from './AccessCard';
 import Mails from './Mails';

--- a/src/profile/components/Settings/index.tsx
+++ b/src/profile/components/Settings/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { RouteProps, Switch } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
 
 import HttpError from 'core/components/errors/HttpError';
-import { Route } from 'core/components/Router';
+import { IRouteProps, Route } from 'core/components/Router';
 import { IProfileProps } from 'profile';
 import AccessCard from './AccessCard';
 import Mails from './Mails';
@@ -37,7 +37,7 @@ const Settings = (_: IProfileProps) => {
   );
 };
 
-interface ISettingsRouteProps extends RouteProps {
+interface ISettingsRouteProps extends IRouteProps {
   view: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 

--- a/src/profile/components/Statistics/index.tsx
+++ b/src/profile/components/Statistics/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { RouteProps, Switch } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
 
 import HttpError from 'core/components/errors/HttpError';
-import { Route } from 'core/components/Router';
+import { IRouteProps, Route } from 'core/components/Router';
 import Orders from './Orders';
 
 const BASE_ROUTE = '/profile/statistics';
@@ -20,7 +20,7 @@ const Settings = () => {
   );
 };
 
-interface ISettingsRouteProps extends RouteProps {
+interface ISettingsRouteProps extends IRouteProps {
   view: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 

--- a/src/profile/components/Statistics/index.tsx
+++ b/src/profile/components/Statistics/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { RouteProps, Switch } from 'react-router-dom';
 
 import HttpError from 'core/components/errors/HttpError';
-import Route from 'core/components/Route';
+import { Route } from 'core/components/Router';
 import Orders from './Orders';
 
 const BASE_ROUTE = '/profile/statistics';

--- a/src/profile/index.tsx
+++ b/src/profile/index.tsx
@@ -1,5 +1,5 @@
 import HttpError from 'core/components/errors/HttpError';
-import Route from 'core/components/Route';
+import { Route } from 'core/components/Router';
 import { History } from 'history';
 import 'multirange';
 import qs from 'query-string';

--- a/src/profile/index.tsx
+++ b/src/profile/index.tsx
@@ -1,10 +1,10 @@
 import HttpError from 'core/components/errors/HttpError';
-import { Route } from 'core/components/Router';
+import { IRouteProps, Route } from 'core/components/Router';
 import { History } from 'history';
 import 'multirange';
 import qs from 'query-string';
 import React from 'react';
-import { RouteProps, Switch } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
 import MainMenu from './components/MainMenu';
 import MyProfile from './components/Profile';
 import Search from './components/Search';
@@ -41,7 +41,7 @@ export interface IProfileProps {
   history: History;
 }
 
-interface IProfileRouteProps extends RouteProps {
+interface IProfileRouteProps extends IRouteProps {
   view: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 


### PR DESCRIPTION
Wrapping the Link components in the same way as Route before it. Makes it easy to declare a route as inaccessible without logging in. Can also be extended to add support for permissions if we want to expose those to the user?

- Create a better structure for the current Route wrapper.
- Change a lot of imports from the standard Route and Link implementations to the wrapped ones.
- Create a component which will not render `children` if the user is not logged in.

Fixes #152 