### PR TITLE
Create a statistics page for event attendance

### DIFF
--- a/src/common/components/Charts/CalendarChart.tsx
+++ b/src/common/components/Charts/CalendarChart.tsx
@@ -2,10 +2,11 @@ import { CalendarDatum, CalendarLegend, ResponsiveCalendar } from '@nivo/calenda
 import classnames from 'classnames';
 import { DateTime } from 'luxon';
 import React from 'react';
-import style from './orders.less';
+import style from './charts.less';
 
 export interface IProps {
-  frequency: DateTime[]; // Datetime
+  frequency: DateTime[];
+  header: string;
 }
 
 const COLORS = {
@@ -34,19 +35,23 @@ const LEGENDS: CalendarLegend[] = [
   },
 ];
 
-const OrderFrequency = ({ frequency }: IProps) => {
+interface IFrequncyCount {
+  [date: string]: number;
+}
+
+const CalendarChart = ({ frequency, header }: IProps) => {
   const last = frequency[frequency.length - 1];
   const first = last.minus({ years: 1 });
   const dateStrings = frequency.map((date) => date.toISODate());
-  const inter: Array<{ [date: string]: number }> = dateStrings.map((date) => ({ [date]: 1 }));
-  const inter2: { [date: string]: number } = inter.reduce((prev, curr) => {
+  const inter: IFrequncyCount[] = dateStrings.map((date) => ({ [date]: 1 }));
+  const inter2: IFrequncyCount = inter.reduce((prev, curr) => {
     const key = Object.keys(curr)[0];
     return { ...prev, [key]: prev[key] + 1 || 1 };
   });
   const values: CalendarDatum[] = Object.keys(inter2).map((key) => ({ day: key, value: inter2[key] }));
   return (
     <div className={classnames(style.centerChart, style.calendarChart)}>
-      <h1>Kjøpskalender</h1>
+      <h1>{header}</h1>
       <ResponsiveCalendar
         from={first.toISODate()}
         to={last.toISODate()}
@@ -59,4 +64,4 @@ const OrderFrequency = ({ frequency }: IProps) => {
   );
 };
 
-export default OrderFrequency;
+export default CalendarChart;

--- a/src/common/components/Charts/charts.less
+++ b/src/common/components/Charts/charts.less
@@ -1,7 +1,18 @@
+@import '~common/less/constants.less';
+
 .centerChart {
   & > div,
   h1 {
     display: flex;
     justify-content: center;
+  }
+}
+
+.calendarChart {
+  height: 450px;
+  max-width: 90vw;
+
+  @media screen and (max-width: @owMobileBreakpoint) {
+    height: 300px;
   }
 }

--- a/src/common/components/Charts/charts.less
+++ b/src/common/components/Charts/charts.less
@@ -1,0 +1,7 @@
+.centerChart {
+  & > div,
+  h1 {
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -20,6 +20,7 @@ export interface IAPIData<T> {
 export interface IBaseAPIParameters {
   page_size?: number;
   page?: number;
+  format?: 'json' | string;
 }
 /*
 const makeRequest = (query: string, parameters: object = {}, options: RequestInit = {}) => {

--- a/src/events/api/events.ts
+++ b/src/events/api/events.ts
@@ -8,7 +8,7 @@ export interface IEventAPIParameters extends IBaseAPIParameters {
   event_end__gte?: string;
   event_end__lte?: string;
   event_type?: number[] | number;
-  is_attendee?: 'True' | 'False' | null;
+  is_attendee?: 'True' | 'False';
 }
 
 export interface IAPIData<T> {

--- a/src/profile/components/Statistics/Events/CompanyDonut.tsx
+++ b/src/profile/components/Statistics/Events/CompanyDonut.tsx
@@ -1,0 +1,57 @@
+import { Pie } from '@nivo/pie';
+import { INewEvent } from 'events/models/Event';
+import React from 'react';
+import style from '../Orders/orders.less';
+
+export interface ICompanyCount {
+  [key: string]: number;
+}
+
+/**
+ * @summary Reduces a list of events into the amount of events that company has had.
+ * @description Reduces a list of events to a an object where the keys are the company name
+ * and the values are the amount of events that company has arranged.
+ * @param {INewEvent[]} events The list events to count companies in.
+ * @returns {ICompanyCount} E.g. { 'Company1': 3, 'Company2': 8 }
+ */
+export function countCompanies(events: INewEvent[]): ICompanyCount {
+  return events.reduce<ICompanyCount>((counted, { company_event }) => {
+    for (const { company } of company_event) {
+      counted[company.name] = counted[company.name] + 1 || 1;
+    }
+    return counted;
+  }, {});
+}
+
+const createPieDatum = (count: ICompanyCount) => {
+  return Object.keys(count).map((key) => ({
+    label: key,
+    value: count[key],
+    id: key,
+  }));
+};
+
+export interface IProps {
+  events: INewEvent[];
+}
+
+const CompanyDonut = ({ events }: IProps) => {
+  const companyCount = countCompanies(events);
+  const companies = createPieDatum(companyCount);
+  return (
+    <div className={style.centerChart}>
+      <h1>Bedrifter</h1>
+      <Pie
+        data={companies}
+        height={300}
+        width={350}
+        fit
+        animate
+        innerRadius={0.6}
+        margin={{ top: 60, right: 30, bottom: 40, left: 30 }}
+      />
+    </div>
+  );
+};
+
+export default CompanyDonut;

--- a/src/profile/components/Statistics/Events/EventTypeDonut.tsx
+++ b/src/profile/components/Statistics/Events/EventTypeDonut.tsx
@@ -1,0 +1,59 @@
+import { Pie, PieDatum } from '@nivo/pie';
+import { getEventColor, getEventType, INewEvent } from 'events/models/Event';
+import React from 'react';
+import style from '../Orders/orders.less';
+
+export interface IProps {
+  events: INewEvent[];
+}
+
+const getColor = ({ label }: PieDatum): string => {
+  if (typeof label === 'number') {
+    return getEventColor(label);
+  }
+  return 'gray';
+};
+
+export interface ITypeCount {
+  [key: string]: number;
+}
+
+function countEventTypes(events: INewEvent[]): ITypeCount {
+  return events.reduce<ITypeCount>(
+    (counted, event) => ({
+      ...counted,
+      [event.event_type]: counted[event.event_type] + 1 || 1,
+    }),
+    {}
+  );
+}
+
+const createPieDatum = (count: ITypeCount) => {
+  return Object.keys(count).map((key) => ({
+    label: Number(key),
+    value: count[key],
+    id: getEventType(Number(key)),
+  }));
+};
+
+const EventTypeDonut = ({ events }: IProps) => {
+  const typeCount = countEventTypes(events);
+  const eventTypes = createPieDatum(typeCount);
+  return (
+    <div className={style.centerChart}>
+      <h1>Arrangementstyper</h1>
+      <Pie
+        data={eventTypes}
+        height={300}
+        width={350}
+        fit
+        animate
+        innerRadius={0.6}
+        colorBy={getColor}
+        margin={{ top: 60, right: 30, bottom: 40, left: 30 }}
+      />
+    </div>
+  );
+};
+
+export default EventTypeDonut;

--- a/src/profile/components/Statistics/Events/StringStat.tsx
+++ b/src/profile/components/Statistics/Events/StringStat.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import style from './events.less';
+
+export interface IProps {
+  name: string;
+  value: string;
+}
+
+const StringStat = ({ name, value }: IProps) => (
+  <div className={style.stringStat}>
+    <h2>{name}</h2>
+    <p>{value}</p>
+  </div>
+);
+
+export default StringStat;

--- a/src/profile/components/Statistics/Events/events.less
+++ b/src/profile/components/Statistics/Events/events.less
@@ -1,0 +1,15 @@
+@import '~common/less/colors.less';
+
+.stringStat {
+  text-align: center;
+  & > h2 {
+    color: @gray;
+  }
+
+  & > p {
+    color: @bedpres;
+    padding: 20px 0 0;
+    font-size: 32px;
+    font-weight: bold;
+  }
+}

--- a/src/profile/components/Statistics/Events/index.tsx
+++ b/src/profile/components/Statistics/Events/index.tsx
@@ -1,0 +1,79 @@
+import { IUserContext, UserContext } from 'authentication/providers/UserProvider';
+import CalendarChart from 'common/components/Charts/CalendarChart';
+import { FourSplitPane, Page, Pane, SplitPane } from 'common/components/Panes';
+import { getAllUserEvents } from 'events/api/events';
+import { INewEvent } from 'events/models/Event';
+import { DateTime } from 'luxon';
+import React, { Component } from 'react';
+import NumberStat from '../Orders/NumberStat';
+import CompanyDonut, { countCompanies } from './CompanyDonut';
+import EventTypeDonut from './EventTypeDonut';
+import StringStat from './StringStat';
+
+export interface IProps {}
+
+export interface IState {
+  events: INewEvent[];
+}
+
+class Orders extends Component<IProps, IState> {
+  public static contextType = UserContext;
+  public state: IState = {
+    events: [],
+  };
+
+  public async componentDidMount() {
+    const { user }: IUserContext = this.context;
+    if (user) {
+      const events = await getAllUserEvents({ is_attendee: 'True' }, user);
+      this.setState({ events });
+    }
+  }
+
+  public render() {
+    const { events } = this.state;
+    const companyPresentations = events.filter(({ event_type }) => event_type === 2);
+    const courses = events.filter(({ event_type }) => event_type === 3);
+    const social = events.filter(({ event_type }) => event_type === 1);
+    const companyEvents = events.filter(({ company_event }) => !!company_event.length);
+    const companyCount = countCompanies(events);
+    const keys = Object.keys(companyCount);
+    const favCompany = keys.reduce((maxKey, key) => (companyCount[key] > companyCount[maxKey] ? key : maxKey), keys[0]);
+    const dates = events.map((event) => DateTime.fromISO(event.event_start));
+    return (
+      <Page loading={events.length === 0}>
+        <SplitPane>
+          <FourSplitPane>
+            <Pane>
+              <NumberStat name="Antall arrangementer" value={events.length} />
+            </Pane>
+            <Pane>
+              <NumberStat name="Antall Sosiale" value={social.length} />
+            </Pane>
+          </FourSplitPane>
+          <Pane>{events.length && <EventTypeDonut events={events} />}</Pane>
+        </SplitPane>
+        <SplitPane>
+          <Pane>{events.length && <CompanyDonut events={events} />}</Pane>
+          <FourSplitPane>
+            <Pane>
+              <StringStat name="Favorittbedrift" value={favCompany} />
+            </Pane>
+            <Pane>
+              <NumberStat name="Antall bedrifts- arrangementer" value={companyEvents.length} />
+            </Pane>
+            <Pane>
+              <NumberStat name="Antall Bedpres" value={companyPresentations.length} />
+            </Pane>
+            <Pane>
+              <NumberStat name="Antall Kurs" value={courses.length} />
+            </Pane>
+          </FourSplitPane>
+        </SplitPane>
+        <Pane>{dates.length && <CalendarChart frequency={dates} header="Arrangementsdatoer" />}</Pane>
+      </Page>
+    );
+  }
+}
+
+export default Orders;

--- a/src/profile/components/Statistics/Main.tsx
+++ b/src/profile/components/Statistics/Main.tsx
@@ -1,7 +1,7 @@
 import Markdown from 'common/components/Markdown';
 import { FourSplitPane, Page, Pane, SplitPane } from 'common/components/Panes';
+import { Link } from 'core/components/Router';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { routes } from './';
 import StringStat from './Events/StringStat';
 

--- a/src/profile/components/Statistics/Main.tsx
+++ b/src/profile/components/Statistics/Main.tsx
@@ -1,0 +1,40 @@
+import Markdown from 'common/components/Markdown';
+import { FourSplitPane, Page, Pane, SplitPane } from 'common/components/Panes';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { routes } from './';
+import StringStat from './Events/StringStat';
+
+const ABOUT_STATISTICS = `
+  # Statistikk
+
+  Her kan du se statistikk for forskjellige metrikker relatert til din bruker.
+
+  _Denne statistikken vises kun for deg, og brukes ikke av Online på noen måte._
+`;
+
+const Main = () => {
+  return (
+    <Page>
+      <Pane>
+        <Markdown source={ABOUT_STATISTICS} />
+      </Pane>
+      <SplitPane>
+        <FourSplitPane>
+          <Link to={routes.orders}>
+            <Pane>
+              <StringStat name="" value="Kiosk" />
+            </Pane>
+          </Link>
+          <Link to={routes.events}>
+            <Pane>
+              <StringStat name="" value="Arrangementer" />
+            </Pane>
+          </Link>
+        </FourSplitPane>
+      </SplitPane>
+    </Page>
+  );
+};
+
+export default Main;

--- a/src/profile/components/Statistics/Orders/index.tsx
+++ b/src/profile/components/Statistics/Orders/index.tsx
@@ -71,7 +71,7 @@ class Orders extends Component<IProps, IState> {
             </Pane>
           </FourSplitPane>
         </SplitPane>
-        <Pane>{frequency.length && <OrderFrequency frequency={frequency} />}</Pane>
+        <Pane>{frequency.length && <CalendarChart frequency={frequency} header="Kjøpskalender" />}</Pane>
       </Page>
     );
   }

--- a/src/profile/components/Statistics/Orders/index.tsx
+++ b/src/profile/components/Statistics/Orders/index.tsx
@@ -1,4 +1,3 @@
-import Markdown from 'common/components/Markdown';
 import { FourSplitPane, Page, Pane, SplitPane } from 'common/components/Panes';
 import { DateTime } from 'luxon';
 import { getOrders } from 'profile/api/orders';
@@ -6,18 +5,10 @@ import { IOrder, IOrderLine } from 'profile/models/Orders';
 import React, { Component, ContextType } from 'react';
 import NumberStat from './NumberStat';
 import OrderBar from './OrderBar';
-import OrderFrequency from './OrderFrequency';
 import OrderItemDonut from './OrderItemDonut';
 
 import { UserContext } from 'authentication/providers/UserProvider';
-
-const ABOUT_STATISTICS = `
-  # Statistikk
-
-  Her kan du se statistikk for forskjellige metrikker relatert til din bruker.
-
-  _Denne statistikken vises kun for deg, og brukes ikke av Online på noen måte._
-`;
+import CalendarChart from 'common/components/Charts/CalendarChart';
 
 export interface IProps {}
 
@@ -50,9 +41,6 @@ class Orders extends Component<IProps, IState> {
     const totalCost = orders.reduce<number>((acc, order) => acc + Number(order.price), 0);
     return (
       <Page loading={orderLines.length === 0}>
-        <Pane>
-          <Markdown source={ABOUT_STATISTICS} />
-        </Pane>
         <Pane>{orderLines.length && <OrderBar orderLines={orderLines} />}</Pane>
         <SplitPane>
           <Pane>{orderLines.length && <OrderItemDonut orderLines={orderLines} />}</Pane>

--- a/src/profile/components/Statistics/Orders/orders.less
+++ b/src/profile/components/Statistics/Orders/orders.less
@@ -28,15 +28,6 @@
   max-width: 90vw;
 }
 
-.calendarChart {
-  height: 450px;
-  max-width: 90vw;
-
-  @media screen and (max-width: @owMobileBreakpoint) {
-    height: 300px;
-  }
-}
-
 .pieChart {
   width: 300px;
   height: 350px;

--- a/src/profile/components/Statistics/index.tsx
+++ b/src/profile/components/Statistics/index.tsx
@@ -3,18 +3,24 @@ import { Switch } from 'react-router-dom';
 
 import HttpError from 'core/components/errors/HttpError';
 import { IRouteProps, Route } from 'core/components/Router';
+import Events from './Events';
+import Main from './Main';
 import Orders from './Orders';
 
 const BASE_ROUTE = '/profile/statistics';
 
 export const routes = {
   main: BASE_ROUTE + '/',
+  events: BASE_ROUTE + '/events',
+  orders: BASE_ROUTE + '/orders',
 };
 
 const Settings = () => {
   return (
     <Switch>
-      <StatisticsRoute exact path={routes.main} view={Orders} />
+      <StatisticsRoute exact path={routes.main} view={Main} />
+      <StatisticsRoute path={routes.orders} view={Orders} />
+      <StatisticsRoute path={routes.events} view={Events} />
       <Route path="*" render={() => <HttpError code={404} text="Undersiden du leter etter finnes ikke" />} />
     </Switch>
   );


### PR DESCRIPTION
Use similar components to Nibble stats to create a statistics page for events a user has attended.

**Requires changes in the back-end of OW4** https://github.com/dotkom/onlineweb4/pull/2187

![screenshot from 2018-12-11 00-30-19](https://user-images.githubusercontent.com/14319313/49768265-0e6f9b00-fcdc-11e8-87b2-46f433127e78.png)

Thoughts for the future:
Make it possible to get a color related to a company. Could be used for statistics, and maybe other things.
Could add it as a field in the database manually, or extract it from the company image somehow?

Main profile statistics page, which I think needs to look different, but I don't have any ideas for it yet:
![screenshot from 2018-12-11 00-40-52](https://user-images.githubusercontent.com/14319313/49768734-a7eb7c80-fcdd-11e8-8dda-7f4d8ffa73cf.png)
