### PR TITLE
fixes committee mail if member is not a committee member

### DIFF
--- a/src/profile/components/Profile/MainProfile.tsx
+++ b/src/profile/components/Profile/MainProfile.tsx
@@ -11,6 +11,12 @@ import Progress from './Progress';
 export interface IProps {
   user: IFullProfileUser;
 }
+const committee_mail = (mail: string): string => {
+  if (mail) {
+    return `${mail}@online.ntnu.no`;
+  }
+  return '';
+};
 
 export const MainProfile = ({ user }: IProps) => (
   <>
@@ -20,7 +26,7 @@ export const MainProfile = ({ user }: IProps) => (
         <Content title="Kontakt">
           <KeyValue k="Telefon" v={user.phone_number} />
           <KeyValue k="E-post" v={user.email} />
-          <KeyValue k="Komité-e-post" v={`${user.online_mail}@online.ntnu.no`} />
+          <KeyValue k="Komité-e-post" v={committee_mail(user.online_mail)} />
         </Content>
       </Pane>
       <Pane>

--- a/src/profile/components/Profile/MainProfile.tsx
+++ b/src/profile/components/Profile/MainProfile.tsx
@@ -11,12 +11,8 @@ import Progress from './Progress';
 export interface IProps {
   user: IFullProfileUser;
 }
-const committee_mail = (mail: string): string => {
-  if (mail) {
-    return `${mail}@online.ntnu.no`;
-  }
-  return '';
-};
+
+const committeeMail = (mail: string) => mail ? `${mail}@online.ntnu.no`  : ''
 
 export const MainProfile = ({ user }: IProps) => (
   <>
@@ -26,7 +22,7 @@ export const MainProfile = ({ user }: IProps) => (
         <Content title="Kontakt">
           <KeyValue k="Telefon" v={user.phone_number} />
           <KeyValue k="E-post" v={user.email} />
-          <KeyValue k="Komité-e-post" v={committee_mail(user.online_mail)} />
+          <KeyValue k="Komité-e-post" v={committeeMail(user.online_mail)} />
         </Content>
       </Pane>
       <Pane>


### PR DESCRIPTION
When a member is not a part of the committee it will say "null@online.ntnu.no". This will just replace this with an empty string. Haven't been able to test if this works since I can't access the profile page to test it. 