### PR TITLE
Create a wrapper component for ResponsiveImage

### DIFF
--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -1,7 +1,7 @@
 import { ICareerOpportunity } from 'career/models/Career';
 import Heading from 'common/components/Heading';
-import Img from 'common/components/Img';
 import Markdown from 'common/components/Markdown';
+import ResponsiveImage from 'common/components/ResponsiveImage';
 import { Link } from 'core/components/Router';
 import { DateTime } from 'luxon';
 import React from 'react';
@@ -27,7 +27,7 @@ const JobDetails = (props: ICareerOpportunity) => (
       <div>
         <div className={style.company}>
           <Link className={style.companyImage} to={`/company/${props.company.id}`}>
-            <Img src={props.company.image.lg} alt={props.company.name} />
+            <ResponsiveImage image={props.company.image} size="lg" alt={props.company.name} />
           </Link>
           <div className={style.companyDescriptionBox}>
             <Link className={style.companyDescriptionTitle} to={`/company/${props.company.id}`}>

--- a/src/career/components/JobListItem.tsx
+++ b/src/career/components/JobListItem.tsx
@@ -1,5 +1,5 @@
 import { ICareerOpportunity } from 'career/models/Career';
-import Img from 'common/components/Img';
+import ResponsiveImage from 'common/components/ResponsiveImage';
 import { Link } from 'core/components/Router';
 import React from 'react';
 import style from '../less/career.less';
@@ -24,7 +24,7 @@ export const formatLocations = (locations: any) => {
 const JobListItem = ({ location, deadline, company, title, ingress, id, employment }: ICareerOpportunity) => (
   <div className={style.job}>
     <Link to={`/career/${id}`}>
-      <Img src={company.image.md} alt="Firmalogo" />
+      <ResponsiveImage image={company.image} size="md" alt="Firmalogo" />
     </Link>
     <div className={style.jobInfo}>
       <Link to={`/career/${id}`}>

--- a/src/common/components/ResponsiveImage/index.tsx
+++ b/src/common/components/ResponsiveImage/index.tsx
@@ -1,0 +1,16 @@
+import React, { ImgHTMLAttributes } from 'react';
+import { DOMAIN } from '../../constants/endpoints';
+import IImage, { IImageSizes } from '../../models/Image';
+
+export interface IProps extends ImgHTMLAttributes<HTMLImageElement> {
+  image: IImage;
+  size: keyof IImageSizes;
+}
+
+const ResponsiveImage = ({ image, size, alt, ...props }: IProps) => {
+  const defaultImage = image[size];
+  const altText = alt || image.name;
+  return <img {...props} src={DOMAIN + defaultImage} alt={altText} />;
+};
+
+export default ResponsiveImage;

--- a/src/common/models/Image.ts
+++ b/src/common/models/Image.ts
@@ -1,4 +1,13 @@
-export default interface IImage {
+export default interface IImage extends IImageSizes {
+  id: number;
+  name: string;
+  timestamp: string;
+  description: string;
+  tags: string[];
+  photographer: string;
+}
+
+export interface IImageSizes {
   thumb: string;
   original: string;
   wide: string;
@@ -7,3 +16,19 @@ export default interface IImage {
   sm: string;
   xs: string;
 }
+
+export const DEFAULT_EVENT_IMAGE: IImage = {
+  id: 95,
+  name: 'Generisk arrangementsbilde',
+  timestamp: '2016-10-16T15:26:40.184370+02:00',
+  description: 'Midlertidig bilde for arrangementer',
+  thumb: '/media/images/responsive/thumbnails/86b20aca-4368-4b3a-8f10-707c747eb03f.png',
+  original: '/media/images/responsive/86b20aca-4368-4b3a-8f10-707c747eb03f.png',
+  wide: '/media/images/responsive/wide/86b20aca-4368-4b3a-8f10-707c747eb03f.png',
+  lg: '/media/images/responsive/lg/86b20aca-4368-4b3a-8f10-707c747eb03f.png',
+  md: '/media/images/responsive/md/86b20aca-4368-4b3a-8f10-707c747eb03f.png',
+  sm: '/media/images/responsive/sm/86b20aca-4368-4b3a-8f10-707c747eb03f.png',
+  xs: '/media/images/responsive/xs/86b20aca-4368-4b3a-8f10-707c747eb03f.png',
+  tags: ['arrangement', 'bilde', 'generisk'],
+  photographer: '',
+};

--- a/src/events/components/DetailView/PictureCard.tsx
+++ b/src/events/components/DetailView/PictureCard.tsx
@@ -1,14 +1,12 @@
-import { DOMAIN } from 'common/constants/endpoints';
 import { DateTime } from 'luxon';
 import React from 'react';
 import { getEventColor, INewEvent } from '../../models/Event';
+import EventImage from '../EventImage';
 import Block from './Block';
 import CardHeader from './Card/CardHeader';
 import style from './detail.less';
 
 const PictureCard = ({ image, event_start, event_end, location, company_event, event_type }: INewEvent) => {
-  const eventImage = company_event[0] ? company_event[0].company.image : image;
-  const imageUrl = eventImage ? eventImage.md : '';
   const color = getEventColor(event_type);
 
   const startDate = DateTime.fromISO(event_start).toFormat('d MMM');
@@ -18,7 +16,7 @@ const PictureCard = ({ image, event_start, event_end, location, company_event, e
 
   return (
     <div className={style.pictureCard}>
-      <img src={DOMAIN + imageUrl} />
+      <EventImage companyEvents={company_event} image={image} size="lg" />
 
       <div className={style.attendance}>
         <CardHeader className={style.detailHeader} color={color}>

--- a/src/events/components/EventImage.tsx
+++ b/src/events/components/EventImage.tsx
@@ -1,0 +1,18 @@
+import ResponsiveImage from 'common/components/ResponsiveImage';
+import IImage, { DEFAULT_EVENT_IMAGE, IImageSizes } from 'common/models/Image';
+import React, { ImgHTMLAttributes } from 'react';
+import { ICompanyEvent } from '../models/Event';
+
+export interface IProps extends ImgHTMLAttributes<HTMLImageElement> {
+  image: IImage | null;
+  companyEvents: ICompanyEvent[];
+  size: keyof IImageSizes;
+}
+
+const EventImage = ({ image, companyEvents: [companyEvent], ...props }: IProps) => {
+  const img = companyEvent ? companyEvent.company.image : image;
+  const src = img || DEFAULT_EVENT_IMAGE;
+  return <ResponsiveImage image={src} {...props} />;
+};
+
+export default EventImage;

--- a/src/events/components/ImageView/LargeEvent.tsx
+++ b/src/events/components/ImageView/LargeEvent.tsx
@@ -1,19 +1,10 @@
-import { DOMAIN } from 'common/constants/endpoints';
-import IImage from 'common/models/Image';
 import { Link } from 'core/components/Router';
-import { getEventColor, getEventType, ICompanyEvent, INewEvent } from 'events/models/Event';
+import { getEventColor, getEventType, INewEvent } from 'events/models/Event';
 import { getEventAttendees } from 'events/utils/attendee';
 import { DateTime } from 'luxon';
 import React from 'react';
+import EventImage from '../EventImage';
 import style from './image.less';
-
-const getEventImage = (image: IImage | null, company_event: ICompanyEvent[]) => {
-  return image
-    ? DOMAIN + image.wide
-    : company_event[0]
-    ? DOMAIN + company_event[0].company.image.wide
-    : 'https://online.ntnu.no/media/images/responsive/md/86b20aca-4368-4b3a-8f10-707c747eb03f.png';
-};
 
 const LargeEvent = ({ image, event_type, title, event_start, attendance_event, id, company_event }: INewEvent) => {
   return (
@@ -22,7 +13,7 @@ const LargeEvent = ({ image, event_type, title, event_start, attendance_event, i
         <h2 className={style.imageLargeType} style={{ background: getEventColor(event_type) }}>
           {getEventType(event_type)}
         </h2>
-        <img className={style.largeImage} src={getEventImage(image, company_event)} />
+        <EventImage className={style.largeImage} image={image} companyEvents={company_event} size="md" />
         <div className={style.largeContent}>
           <p>{title}</p>
           <p>{getEventAttendees(attendance_event)}</p>

--- a/src/events/models/Event.ts
+++ b/src/events/models/Event.ts
@@ -1,4 +1,4 @@
-import IImage from 'common/models/Image';
+import IImage, { DEFAULT_EVENT_IMAGE } from 'common/models/Image';
 import { ICompany } from 'core/models/Company';
 import { IGroup } from 'core/models/Group';
 import { IUser } from 'core/models/User';
@@ -84,15 +84,7 @@ export const mockEvent: INewEvent = {
   event_start: '',
   event_type: 0,
   id: 0,
-  image: {
-    lg: '',
-    md: '/media/images/responsive/md/86b20aca-4368-4b3a-8f10-707c747eb03f.png',
-    original: '',
-    sm: '',
-    thumb: '',
-    wide: '',
-    xs: '',
-  },
+  image: DEFAULT_EVENT_IMAGE,
   ingress: '',
   ingress_short: '',
   location: '',

--- a/src/frontpage/components/Articles/MainArticle.tsx
+++ b/src/frontpage/components/Articles/MainArticle.tsx
@@ -1,5 +1,5 @@
 import { IArticle } from 'articles/models/Article';
-import Img from 'common/components/Img';
+import ResponsiveImage from 'common/components/ResponsiveImage';
 import { DOMAIN } from 'common/constants/endpoints';
 import React from 'react';
 import style from './articles.less';
@@ -8,7 +8,7 @@ const MainArticle = ({ absolute_url, heading, image, ingress }: IArticle) => {
   return (
     <a href={DOMAIN + absolute_url}>
       <div className={style.articleContainer}>
-        <Img src={image.sm} />
+        <ResponsiveImage image={image} size="sm" />
         <div>
           <h2>{heading}</h2>
           <p>{ingress}</p>

--- a/src/frontpage/components/Articles/SmallArticle.tsx
+++ b/src/frontpage/components/Articles/SmallArticle.tsx
@@ -1,6 +1,6 @@
 import { IArticle } from 'articles/models/Article';
 import classnames from 'classnames';
-import Img from 'common/components/Img';
+import ResponsiveImage from 'common/components/ResponsiveImage';
 import { DOMAIN } from 'common/constants/endpoints';
 import React from 'react';
 import style from './articles.less';
@@ -9,7 +9,7 @@ const SmallArticle = ({ absolute_url, heading, image, ingress_short }: IArticle)
   return (
     <a href={DOMAIN + absolute_url}>
       <div className={classnames(style.articleContainer, style.smallArticle)}>
-        <Img src={image.xs} className={style.smallImage} />
+        <ResponsiveImage image={image} size="xs" className={style.smallImage} />
         <div>
           <h2>{heading}</h2>
           <p>{ingress_short}</p>


### PR DESCRIPTION
Correctly handle OW4 Responsive Images with a component which renders a specified version of the image.

Could be expanded in the future to use `srcSet` to make load correct images for the size of the image on the screen?