### PR TITLE
[W.I.P] Create a module to show information about the Online Office

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import HttpError from './core/components/errors/HttpError';
 import { Route } from './core/components/Router';
 import Frontpage from './frontpage';
 import Hobbys from './hobbygroups';
+import Office from './office';
 import Resources from './resources';
 
 /** Luxon locale setting has to be the same as in the front-end */
@@ -30,6 +31,7 @@ export const routes = {
   profile: '/profile',
   authCallback: '/auth/callback',
   spinner: '/spinner',
+  office: '/office',
 };
 
 const LoadableProfile = Loadable({
@@ -57,6 +59,7 @@ export const Client = () => (
       <Route path={routes.profile} component={LoadableProfile} requireLogin />
       <Route path={routes.authCallback} component={AuthCallback} />
       <Route path={routes.spinner} component={Spinner} />
+      <Route path={routes.office} component={Office} />
       <Route path="*" render={() => <HttpError code={404} />} />
     </Switch>
   </Core>

--- a/src/common/constants/google.ts
+++ b/src/common/constants/google.ts
@@ -1,1 +1,2 @@
 export const GA_KEY = process.env.OWF_GOOGLE_ANALYTICS_KEY || 'UA-000000000-0';
+export const GCAL_KEY = process.env.OWF_GOOGLE_CALENDAR_KEY || '';

--- a/src/common/utils/api/google/calendar.ts
+++ b/src/common/utils/api/google/calendar.ts
@@ -1,0 +1,23 @@
+import { get } from '..';
+import { GCAL_KEY } from '../../../constants/google';
+import { ICalendarResult } from './models/calendar';
+
+const DOMAIN = 'https://www.googleapis.com';
+const API_URL = '/calendar/v3/calendars/';
+
+export interface IGoogleCalendarParams {
+  singleEvents?: boolean;
+  timeMax?: string;
+  timeMin?: string;
+}
+
+export interface IGetCalendarParams {
+  calendarId: string;
+  params: IGoogleCalendarParams;
+}
+
+export const getCalendar = async (opts: IGetCalendarParams): Promise<ICalendarResult> => {
+  const parameters = { ...opts.params, key: GCAL_KEY };
+  const url = `${API_URL}${opts.calendarId}/events`;
+  return await get(url, parameters, { domain: DOMAIN });
+};

--- a/src/common/utils/api/google/models/calendar.ts
+++ b/src/common/utils/api/google/models/calendar.ts
@@ -1,0 +1,50 @@
+export interface ICalendarResult {
+  kind: string;
+  /** Should be numeric */
+  etag: string;
+  summary: string;
+  description: string;
+  /** ISO8601 DateTime */
+  updated: string;
+  timeZone: string;
+  accessRole: string;
+  defaultReminders: any[];
+  nextPageToken: string;
+  items: ICalendarItem[];
+}
+
+export interface ICalendarItem {
+  kind: string;
+  /** Should be numeric */
+  etag: string;
+  id: string;
+  status: string;
+  htmlLink: string;
+  /** ISO8601 DateTime */
+  created: string;
+  /** ISO8601 DateTime */
+  updated: string;
+  summary: string;
+  creator: IGoogleAPICreator;
+  organizer: IGoogleAPICreator;
+  start: IGoogleAPITime;
+  end: IGoogleAPITime;
+  iCalUID: string;
+  sequence: number;
+  reminders: IGoogleAPIReminders;
+}
+
+export interface IGoogleAPICreator {
+  email: string;
+  displayName: string;
+  self?: boolean;
+}
+
+export interface IGoogleAPITime {
+  /** ISO8601 DateTime */
+  dateTime: string;
+}
+
+export interface IGoogleAPIReminders {
+  useDefault: boolean;
+}

--- a/src/common/utils/api/index.ts
+++ b/src/common/utils/api/index.ts
@@ -1,13 +1,14 @@
 import 'isomorphic-fetch';
-import { DOMAIN } from '../constants/endpoints';
-import { __CLIENT__ } from '../constants/environment';
-import { toQueryString } from './queryString';
+import { DOMAIN } from '../../constants/endpoints';
+import { __CLIENT__ } from '../../constants/environment';
+import { toQueryString } from '../queryString';
 
 import { IAuthUser } from 'authentication/models/User';
-import { getCache, hasCache, IRequestCacheOptions, setCache } from './requestCache';
+import { getCache, hasCache, IRequestCacheOptions, setCache } from '../requestCache';
 
 export interface IRequestOptions extends RequestInit {
   cacheOptions?: IRequestCacheOptions;
+  domain?: string;
 }
 
 export interface IAPIData<T> {
@@ -29,7 +30,7 @@ const makeRequest = (query: string, parameters: object = {}, options: RequestIni
 */
 const performRequest = async (query: string, parameters: object = {}, options: IRequestOptions = {}) => {
   const queryString = toQueryString(parameters);
-  const url = DOMAIN + query + queryString;
+  const url = (options.domain || DOMAIN) + query + queryString;
   const { cacheOptions } = options;
   if (hasCache({ url, options: cacheOptions })) {
     const { cache } = getCache({ url, options: cacheOptions });

--- a/src/common/utils/queryString.ts
+++ b/src/common/utils/queryString.ts
@@ -8,7 +8,7 @@ export const toQueryString = (queryObject: any): string => {
   if (!keys.length) {
     return '';
   }
-  const queries = keys.map((key: string) => `${key}=${queryObject[key]}`);
+  const queries = keys.map((key: string) => `${key}=${encodeURIComponent(queryObject[key])}`);
   return `?${queries.join('&')}`;
 };
 

--- a/src/events/providers/CalendarEvents.tsx
+++ b/src/events/providers/CalendarEvents.tsx
@@ -18,7 +18,7 @@ export interface ICalendarEventsState {
  * The events are stored in a '2D list', where each index of the outer list represents a day in the month.
  * For more information, see the description of the 'contructMonthMap' function.
  */
-const EMPTY_EVENT_MONTH = constructMonthMap(DateTime.local(), []);
+const EMPTY_EVENT_MONTH = constructMonthMap(DateTime.local(), [], () => '');
 
 const INITIAL_STATE: ICalendarEventsState = {
   /** The empty month will let the calendar render all the tiles even without events in it */
@@ -62,7 +62,7 @@ class CalendarEvents extends Component<IProps, ICalendarEventsState> {
   public static async getServerState(_: IProps): Promise<IPrefetch> {
     const month = DateTime.local();
     const data = await getCalendarEvents(month);
-    const eventMonth = constructMonthMap(month, data);
+    const eventMonth = constructMonthMap(month, data, (event) => event.event_start);
     return { eventMonth, month };
   }
 
@@ -131,7 +131,7 @@ class CalendarEvents extends Component<IProps, ICalendarEventsState> {
 
     /** Await the events, construct the month representation and set it to state */
     const { results } = await data;
-    const eventMonth = constructMonthMap(month, results);
+    const eventMonth = constructMonthMap(month, results, (event) => event.event_start);
     this.setState({ eventMonth });
   };
 

--- a/src/events/utils/calendarUtils.ts
+++ b/src/events/utils/calendarUtils.ts
@@ -1,5 +1,4 @@
 import { DateTime } from 'luxon';
-import { INewEvent } from '../models/Event';
 
 /**
  * Returns the weekday of the first day of a month from a date object.
@@ -67,17 +66,17 @@ export function getMonthAndYear(date: Date) {
  * The outer Array represents the ((day of the month) - 1) the event is on,
  * while the inner Array represents the events on that day.
  * @param {DateTime} month Current month.
- * @param {INewEvent[]} events Events to inject into the month model.
- * @returns {INewEvent[][]} Events represented in a month model.
+ * @param {(typeof events)[]} events Events to inject into the month model.
+ * @returns {(typeof events)[][]} Events represented in a month model.
  */
-export const constructMonthMap = (month: DateTime, events: INewEvent[]): INewEvent[][] => {
+export const constructMonthMap = <T>(month: DateTime, events: T[], getDate: (o: T) => string): T[][] => {
   /**
    * @summary Create an empty EventMonth.
    * @description Create an array of length `daysInMonth`, containing empty arrays.
    */
   const map = [...Array(month.daysInMonth)].map(() => Array(0).fill([]));
   events.forEach((event) => {
-    const day = DateTime.fromISO(event.event_start).day - 1;
+    const day = DateTime.fromISO(getDate(event)).day - 1;
     map[day].push(event);
   });
   return map;

--- a/src/office/api/backedProxy.ts
+++ b/src/office/api/backedProxy.ts
@@ -1,0 +1,23 @@
+import { getCalendar, IGetCalendarParams, IGoogleCalendarParams } from 'common/utils/api/google/calendar';
+import { ICalendarResult } from 'common/utils/api/google/models/calendar';
+
+const OFFICE_SCHEDULE_ID = '54v6g4v6r46qi4asf7lh5j9pcs@group.calendar.google.com';
+const OFFICE_ATTENDANTS_SCHEDULE_ID = '';
+
+/**
+ * @protected Can only be used on the back-end.
+ */
+export const getOfficeSchedule = async (params: IGoogleCalendarParams): Promise<ICalendarResult> => {
+  const opts: IGetCalendarParams = { calendarId: OFFICE_SCHEDULE_ID, params };
+  const calendar = await getCalendar(opts);
+  return calendar;
+};
+
+/**
+ * @protected Can only be used on the back-end.
+ */
+export const getOfficeAttendants = async (params: IGoogleCalendarParams): Promise<ICalendarResult> => {
+  const opts: IGetCalendarParams = { calendarId: OFFICE_ATTENDANTS_SCHEDULE_ID, params };
+  const calendar = await getCalendar(opts);
+  return calendar;
+};

--- a/src/office/api/schedule.ts
+++ b/src/office/api/schedule.ts
@@ -1,0 +1,11 @@
+import { get } from 'common/utils/api';
+import { IGoogleCalendarParams } from 'common/utils/api/google/calendar';
+import { ICalendarResult } from 'common/utils/api/google/models/calendar';
+import { BASE_ROUTE, routes } from 'office/backend/routes';
+
+const API_URL = BASE_ROUTE + routes.schedule;
+
+export const getOfficeSchedule = async (params: IGoogleCalendarParams): Promise<ICalendarResult> => {
+  const results: ICalendarResult = await get(API_URL, params, { domain: window.location.origin });
+  return results;
+};

--- a/src/office/backend/router.ts
+++ b/src/office/backend/router.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+
+import { IGoogleCalendarParams } from 'common/utils/api/google/calendar';
+import { getOfficeSchedule } from 'office/api/backedProxy';
+
+import { BASE_ROUTE, routes } from './routes';
+
+const router = Router();
+
+router.get(routes.schedule, async (req, res) => {
+  const { singleEvents = true, timeMax, timeMin }: IGoogleCalendarParams = req.query;
+  const calendar = await getOfficeSchedule({ singleEvents, timeMax, timeMin });
+  res.json(calendar);
+});
+
+const officeRouter = Router();
+
+officeRouter.use(BASE_ROUTE, router);
+
+export default officeRouter;

--- a/src/office/backend/routes.ts
+++ b/src/office/backend/routes.ts
@@ -1,0 +1,7 @@
+import { BASE_ROUTE as parentRoute } from 'server/routes';
+
+export const BASE_ROUTE = parentRoute + '/office';
+
+export const routes = {
+  schedule: '/schedule',
+};

--- a/src/office/components/OfficeSchedule.tsx
+++ b/src/office/components/OfficeSchedule.tsx
@@ -1,0 +1,50 @@
+import React, { ContextType, PureComponent } from 'react';
+
+import style from 'events/components/CalendarView/calendar.less';
+import { CalendarFillerTiles, createDayList } from 'events/components/CalendarView/CalendarTile';
+import { getFirstWeekdayOfMonth, getPreviousMonthLength } from 'events/utils/calendarUtils';
+import { OfficeCalendarContext } from 'office/providers/OfficeCalendar';
+
+import ScheduleTile from './ScheduleTile';
+
+class OfficeSchedule extends PureComponent<{}> {
+  public static contextType = OfficeCalendarContext;
+  public context!: ContextType<typeof OfficeCalendarContext>;
+
+  public render() {
+    const { eventMonth, month } = this.context;
+
+    const firstWeekDay = getFirstWeekdayOfMonth(month.toJSDate());
+    const lastDayPrevMonth = getPreviousMonthLength(month.toJSDate());
+
+    const previous = createDayList(firstWeekDay, lastDayPrevMonth - firstWeekDay);
+    // 7 - 'number of days last week of the month' if 'number of days in last week' is not 0
+    const next = createDayList(
+      (month.daysInMonth + firstWeekDay) % 7 === 0 ? 0 : 7 - ((month.daysInMonth + firstWeekDay) % 7),
+      0
+    );
+
+    return (
+      <div className={style.gridWrapper}>
+        <div className={style.menuGrid}>
+          <h3 className={style.monthChanger} onClick={() => ({})} tabIndex={0}>
+            {'<'}
+          </h3>
+          <h3>{month.toFormat('MMMM yyyy')}</h3>
+          <h3 className={style.monthChanger} onClick={() => ({})} tabIndex={0}>
+            {'>'}
+          </h3>
+        </div>
+        <div className={style.grid}>
+          <CalendarFillerTiles days={previous} />
+          {eventMonth.map((events, index) => (
+            <ScheduleTile key={`${month.toFormat('yyyy-MM')}-${index + 1}`} events={events} day={index + 1} active />
+          ))}
+          <CalendarFillerTiles days={next} />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default OfficeSchedule;

--- a/src/office/components/ScheduleEvent.tsx
+++ b/src/office/components/ScheduleEvent.tsx
@@ -1,0 +1,20 @@
+import classnames from 'classnames';
+import React, { Props } from 'react';
+
+import calendarStyle from 'events/components/CalendarView/calendar.less';
+import style from './style.less';
+
+export interface IProps extends Props<any> {
+  title: string;
+  color: string;
+}
+
+const ScheduleEvent = ({ title }: IProps) => {
+  return (
+    <p className={classnames(calendarStyle.title, style.eventColor)} title={title}>
+      {title}
+    </p>
+  );
+};
+
+export default ScheduleEvent;

--- a/src/office/components/ScheduleTile.tsx
+++ b/src/office/components/ScheduleTile.tsx
@@ -1,0 +1,31 @@
+import classnames from 'classnames';
+import React from 'react';
+
+import { ICalendarItem } from 'common/utils/api/google/models/calendar';
+import style from 'events/components/CalendarView/calendar.less';
+import ScheduleEvent from './ScheduleEvent';
+
+export interface IProps {
+  events: ICalendarItem[];
+  active?: boolean;
+  day: number;
+}
+
+const ScheduleTile = ({ events, active = true, day }: IProps) => {
+  return (
+    <div
+      className={classnames(style.tile, {
+        [style.tileInactive]: !active,
+      })}
+    >
+      <div className={style.tileContent}>
+        <p>{day}</p>
+        {events.map((event) => (
+          <ScheduleEvent key={event.id} title={event.summary} color={event.kind} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleTile;

--- a/src/office/components/style.less
+++ b/src/office/components/style.less
@@ -1,0 +1,9 @@
+@import '~common/less/colors.less';
+
+.eventColor {
+  background: @lightBlue;
+}
+
+.section {
+  width: 100%;
+}

--- a/src/office/index.tsx
+++ b/src/office/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import OfficeSchedule from './components/OfficeSchedule';
+import style from './components/style.less';
+import OfficeCalendarProvider from './providers/OfficeCalendar';
+
+const Office = () => {
+  return (
+    <section className={style.section}>
+      <OfficeCalendarProvider>
+        <OfficeSchedule />
+      </OfficeCalendarProvider>
+    </section>
+  );
+};
+
+export default Office;

--- a/src/office/providers/OfficeCalendar.tsx
+++ b/src/office/providers/OfficeCalendar.tsx
@@ -1,0 +1,58 @@
+import { DateTime } from 'luxon';
+import React, { Component, createContext } from 'react';
+
+import { ICalendarItem } from 'common/utils/api/google/models/calendar';
+import { constructMonthMap } from 'events/utils/calendarUtils';
+import { getOfficeSchedule } from 'office/api/schedule';
+
+export interface IOfficeCalendarState {
+  eventMonth: ICalendarItem[][];
+  month: DateTime;
+  init: () => void;
+}
+
+const INITIAL_STATE: IOfficeCalendarState = {
+  eventMonth: [],
+  month: DateTime.local(),
+  init: () => {
+    throw new Error('Initial state init() was called without beeing overwritten');
+  },
+};
+
+export const OfficeCalendarContext = createContext(INITIAL_STATE);
+
+class OfficeCalendar extends Component<{}, IOfficeCalendarState> {
+  public state: IOfficeCalendarState = {
+    ...INITIAL_STATE,
+  };
+
+  public componentDidMount() {
+    this.init();
+  }
+
+  public init = async () => {
+    this.fetchEvents();
+  };
+
+  public async fetchEvents() {
+    const { month } = this.state;
+    const firstDayOfMonth = month.minus({ days: month.day - 1 });
+    const lastDayOfMonth = firstDayOfMonth.plus({ months: 1 }).minus({ days: 1 });
+
+    const calendarData = await getOfficeSchedule({
+      singleEvents: true,
+      timeMax: lastDayOfMonth.toISO(),
+      timeMin: firstDayOfMonth.toISO(),
+    });
+    const eventMonth = constructMonthMap(month, calendarData.items, ({ start }: ICalendarItem) => start.dateTime);
+    this.setState({ eventMonth });
+  }
+
+  public render() {
+    const { init } = this;
+    const value = { init, ...this.state };
+    return <OfficeCalendarContext.Provider value={value}>{this.props.children}</OfficeCalendarContext.Provider>;
+  }
+}
+
+export default OfficeCalendar;

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -16,6 +16,7 @@ import { StaticRouter } from 'react-router-dom';
 import serialize from 'serialize-javascript';
 
 import { App } from '../App';
+import { apiRouter } from './router';
 
 /**
  * Server side rendering uses a very simple single route express server to handle
@@ -40,6 +41,7 @@ app.use(cookieParser());
 /** Public folders are currently not set up corectly, TODO: Fix it? */
 app.use('/public', express.static(path.resolve(__dirname, '../dist')));
 app.use('/public', express.static('./dist'));
+app.use(apiRouter);
 
 interface IWebpackAssets {
   [key: string]: {

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import officeRouter from 'office/backend/router';
+
+export const apiRouter = Router();
+
+apiRouter.use(officeRouter);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1,0 +1,1 @@
+export const BASE_ROUTE = '/api';


### PR DESCRIPTION
Module/app for the Online office.

Aims to show the calendar, today's servants and maybe some form of a leaderboard for Nibble.

Uses the express backend as a proxy to wrap the google API, instead of giving all freedom with our Google keys to our users.

I think generalizing the EventCalendar would abstract all meaning away from it, to the point where it would not be worth it. Some of the code from the EventCalendar is instead copied, while other parts are abstracted and reused.

