### PR TITLE
Fix overflow-x on root and revert header changes

### DIFF
--- a/src/core/components/Header/header.less
+++ b/src/core/components/Header/header.less
@@ -9,7 +9,6 @@
 .header {
   background: @darkBlue;
   position: relative;
-  padding: 1vh 4vw;
 }
 
 .grid {
@@ -20,6 +19,7 @@
   margin: auto;
   justify-content: space-between;
   align-items: center;
+  padding: 10px 20px;
 }
 
 .menuButton {

--- a/src/core/less/core.less
+++ b/src/core/less/core.less
@@ -11,6 +11,7 @@
   #root {
     display: grid;
     grid-template-rows: auto 1fr auto;
+    grid-template-columns: 100%;
     height: 100%;
   }
 }


### PR DESCRIPTION
Seems like the whole issue was in the core CSS (core.less file).

Before:
![image](https://user-images.githubusercontent.com/8504538/53575148-47980880-3b71-11e9-8691-ae82f7af14c9.png)

After:
![image](https://user-images.githubusercontent.com/8504538/53575219-6b5b4e80-3b71-11e9-8dd9-d2f2288ac05f.png)

Fix #199 