### PR TITLE
Fix issue #202 by setting a min-width to the button

### DIFF
--- a/src/core/components/Header/header.less
+++ b/src/core/components/Header/header.less
@@ -26,6 +26,7 @@
   position: relative;
   height: 57px;
   width: 57px;
+  min-width: 57px;
   background: none;
   border: none;
   margin: -20px 0 -20px -20px;


### PR DESCRIPTION
Now the button will not shrink, at least:
![image](https://user-images.githubusercontent.com/8504538/53765729-23ba2700-3ed1-11e9-920d-28d0733b7681.png)
Before change:
![image](https://user-images.githubusercontent.com/8504538/53765814-5ebc5a80-3ed1-11e9-82f0-ba747d2f074b.png)

Though the overflow can be a problem. But it is much better with overflow than not reaching the menu.

Fix #202 