### PR TITLE
Fix missing unit in .drone.yml as of drone-ssh

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -84,7 +84,7 @@ pipeline:
     port: 22
     username: root
     key: ${SSH_KEY}
-    command_timeout: 600
+    command_timeout: 600s
     when:
       event: push
       branch: master


### PR DESCRIPTION
The `appleboy/drone-ssh` plugin has recently changed and does now require units.

## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [x] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Add unit, s, to `.drone.yml` file on command_timeout on plugin. Error before fix:

```
could not parse 600 as duration for flag command.timeout,T: time: missing unit in duration 600
```
