### PR TITLE
Increase z-index of dropdown-menu

### DIFF
--- a/src/core/components/Header/header.less
+++ b/src/core/components/Header/header.less
@@ -96,7 +96,7 @@
     right: 0;
     flex-direction: column;
     background-color: #191919;
-    z-index: 1;
+    z-index: 69;
 
     & > a {
       line-height: 40px;


### PR DESCRIPTION
- To make it override the lightning in our loading-spinner

Fixes the issue we were informed about on by mail