### PR TITLE
Fix for issue #212

### DIFF
--- a/src/events/components/ImageView/SmallEvent.tsx
+++ b/src/events/components/ImageView/SmallEvent.tsx
@@ -25,7 +25,13 @@ const SmallEvent = ({ title, event_type, event_start, attendance_event, id, comp
 );
 
 const SmallEventColumn = ({ events }: { events: INewEvent[] }) => {
-  return events.map((event) => <SmallEvent key={event.id} {...event} />);
+  return (
+    <>
+      {events.map((event) => (
+        <SmallEvent key={event.id} {...event} />
+      ))}
+    </>
+  );
 };
 
 export default SmallEventColumn;

--- a/src/events/components/ImageView/SmallEvent.tsx
+++ b/src/events/components/ImageView/SmallEvent.tsx
@@ -27,7 +27,11 @@ const SmallEvent = ({ title, event_type, event_start, attendance_event, id, comp
 const SmallEventColumn = ({ events }: { events: INewEvent[] }) => {
   let column = events.map((event) => <SmallEvent key={event.id} {...event} />);
 
-  column = column.concat([...Array(3 - column.length)].map((_, i) => <a key={i} />));
+  if (events.length > 3) {
+    column = column.concat([...Array(3 - column.length)].map((_, i) => <a key={i} />));
+  } else {
+    column = column.concat([...Array(column.length)].map((_, i) => <a key={i} />));
+  }
 
   return <>{column}</>;
 };

--- a/src/events/components/ImageView/SmallEvent.tsx
+++ b/src/events/components/ImageView/SmallEvent.tsx
@@ -25,15 +25,7 @@ const SmallEvent = ({ title, event_type, event_start, attendance_event, id, comp
 );
 
 const SmallEventColumn = ({ events }: { events: INewEvent[] }) => {
-  let column = events.map((event) => <SmallEvent key={event.id} {...event} />);
-
-  if (events.length > 3) {
-    column = column.concat([...Array(3 - column.length)].map((_, i) => <a key={i} />));
-  } else {
-    column = column.concat([...Array(column.length)].map((_, i) => <a key={i} />));
-  }
-
-  return <>{column}</>;
+  return events.map((event) => <SmallEvent key={event.id} {...event} />);
 };
 
 export default SmallEventColumn;

--- a/src/events/components/ImageView/image.less
+++ b/src/events/components/ImageView/image.less
@@ -3,8 +3,7 @@
 
 @edge-height: 20px;
 
-.largeEventGrid,
-.smallEventGrid {
+.eventGrid {
   display: grid;
   grid-template-columns: 1fr;
   grid-gap: 20px;
@@ -18,27 +17,25 @@
   }
 }
 
-.smallEventGrid {
-  margin-top: 20px;
+@media (min-width: @owTabletBreakpoint + 1) {
+  .eventGrid {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+  .large {
+    max-height: 19rem;
+  }
 }
 
-@media (min-width: @owTabletBreakpoint + 1) {
-  .largeEventGrid {
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-
-  .smallEventGrid {
-    grid-auto-flow: column;
-    grid-template-rows: 1fr 1fr 1fr;
-    grid-template-columns: 1fr 1fr 1fr;
-  }
+.eventColumn {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-gap: 20px;
 }
 
 .large {
   display: flex;
   flex-direction: column;
   .owCard();
-  height: 100%;
 }
 
 .imageLargeType {
@@ -60,7 +57,6 @@
 .largeImageEmpty {
   height: 100%;
   margin: auto;
-  border-bottom: 0.5px solid #b7b7b7;
 
   path {
     fill: @lightGray;
@@ -145,8 +141,7 @@
     font-size: 20px;
   }
   // Change size so that the cards aren't too big
-  .largeEventGrid,
-  .smallEventGrid {
+  .eventGrid {
     width: 70%;
     margin: auto;
   }
@@ -164,8 +159,7 @@
   .suppText {
     max-width: 35px;
   }
-  .largeEventGrid,
-  .smallEventGrid {
+  .eventGrid {
     width: 100%;
     margin: 0;
   }

--- a/src/events/components/ImageView/index.tsx
+++ b/src/events/components/ImageView/index.tsx
@@ -82,27 +82,37 @@ export const ImageView = ({  }: IProps) => {
 
   return (
     <>
-      <div className={style.largeEventGrid}>
-        {displayEvents.eventsLeft[0] ? (
-          <LargeEvent {...displayEvents.eventsLeft[0]} />
-        ) : (
-          <LargeEventPlaceholder event_type={2} />
-        )}
-        {displayEvents.eventsMiddle[0] ? (
-          <LargeEvent {...displayEvents.eventsMiddle[0]} />
-        ) : (
-          <LargeEventPlaceholder event_type={3} />
-        )}
-        {displayEvents.eventsRight[0] ? (
-          <LargeEvent {...displayEvents.eventsRight[0]} />
-        ) : (
-          <LargeEventPlaceholder event_type={1} />
-        )}
-      </div>
-      <div className={style.smallEventGrid}>
-        <SmallEventColumn events={displayEvents.eventsLeft.slice(1, 4)} />
-        <SmallEventColumn events={displayEvents.eventsMiddle.slice(1, 4)} />
-        <SmallEventColumn events={displayEvents.eventsRight.slice(1, 4)} />
+      <div className={style.eventGrid}>
+        <div className={style.eventColumn}>
+          {displayEvents.eventsLeft[0] ? (
+            <>
+              <LargeEvent {...displayEvents.eventsLeft[0]} />
+              <SmallEventColumn events={displayEvents.eventsLeft.slice(1, 4)} />
+            </>
+          ) : (
+            <LargeEventPlaceholder event_type={2} />
+          )}
+        </div>
+        <div className={style.eventColumn}>
+          {displayEvents.eventsMiddle[0] ? (
+            <>
+              <LargeEvent {...displayEvents.eventsMiddle[0]} />
+              <SmallEventColumn events={displayEvents.eventsMiddle.slice(1, 4)} />
+            </>
+          ) : (
+            <LargeEventPlaceholder event_type={3} />
+          )}
+        </div>
+        <div className={style.eventColumn}>
+          {displayEvents.eventsRight[0] ? (
+            <>
+              <LargeEvent {...displayEvents.eventsRight[0]} />
+              <SmallEventColumn events={displayEvents.eventsRight.slice(1, 4)} />
+            </>
+          ) : (
+            <LargeEventPlaceholder event_type={1} />
+          )}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
# This pull request aims to fix #212.
We now have columns for "Bedpres", "Kurs" and "Sosialt/Annet". This also means that the view on mobile is the way described in #212, meaning we now show all the events of each column after one another (List-items after Card-items).

## Here is a screenshot from before:
<p align="center">
<img src="https://user-images.githubusercontent.com/24507952/55905663-bb96e900-5bd2-11e9-87e2-73c33cb36302.png" alt="before" width="350">
</p>


## Here is a screenshot after the fix:
<p align="center">
<img src="https://user-images.githubusercontent.com/24507952/55905676-c5205100-5bd2-11e9-967c-8d4d04ff1d44.png" alt="after" width="350">
</p>
