### PR TITLE
Decouple carousel from Offline view to create a reusable Carousel

### DIFF
--- a/src/common/components/Carousel/CarouselArrow.tsx
+++ b/src/common/components/Carousel/CarouselArrow.tsx
@@ -1,7 +1,8 @@
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons/';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
-import styles from './offline.less';
+
+import styles from './carousel.less';
 
 export interface IProps {
   direction: 'right' | 'left';

--- a/src/common/components/Carousel/carousel.less
+++ b/src/common/components/Carousel/carousel.less
@@ -1,0 +1,40 @@
+@import '~common/less/mixins.less';
+@import '~common/less/colors.less';
+@import '~common/less/constants.less';
+
+.container {
+  margin-top: 40px;
+  width: 100%;
+}
+
+.carouselContainer {
+  display: flex;
+  scroll-snap-type: x mandatory;
+  overflow-x: scroll;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.carousel {
+  display: flex;
+}
+
+.arrowContainer {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  justify-items: center;
+  margin-bottom: 20px;
+}
+
+.carouselArrow {
+  align-self: center;
+  background: none;
+  font-size: 20px;
+  color: @lightGray;
+  & :hover {
+    color: @gray;
+    cursor: pointer;
+  }
+}

--- a/src/common/components/Carousel/index.tsx
+++ b/src/common/components/Carousel/index.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+
+import Heading from 'common/components/Heading';
+import { IRefObject, useRefMap } from 'common/hooks/useRefMap';
+
+import style from './carousel.less';
+import CarouselArrow from './CarouselArrow';
+
+export interface IProps<T> {
+  children: (values: Array<IRefObject<T, HTMLDivElement>>) => JSX.Element;
+  values: T[];
+  title?: string;
+}
+
+export function Carousel<T>({ children, values: inputValues, title = '' }: IProps<T>) {
+  const initialValues = useMemo(() => inputValues, []);
+  const [values, setValues] = useRefMap<HTMLDivElement, T>(initialValues);
+  const carouselRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setValues(inputValues);
+  }, [inputValues]);
+
+  const getSizes = () => {
+    if (values.length) {
+      const [first] = values;
+      if (first.ref.current && carouselRef.current) {
+        return {
+          element: first.ref.current.scrollWidth,
+          container: carouselRef.current.clientWidth,
+          position: carouselRef.current.scrollLeft,
+        };
+      }
+    }
+    return null;
+  };
+
+  const scrollToIndex = (index: number) => {
+    /** Bound the index by the upper and lower limits of the array */
+    const boundedIndex = index < 0 ? 0 : index >= values.length ? values.length - 1 : index;
+    const target = values[boundedIndex];
+    const ref = target ? target.ref.current : null;
+    if (ref) {
+      ref.scrollIntoView({ behavior: 'smooth', inline: 'nearest' });
+    }
+  };
+
+  const scrollToNextRef = () => {
+    const sizes = getSizes();
+    if (sizes) {
+      /** Calculate number of places to move based on screen size */
+      const amount = Math.floor(sizes.container / sizes.element);
+      /** Calculate current position the array based on location of scroll */
+      const currentIndex = Math.floor(sizes.position / (sizes.element + 20));
+      scrollToIndex(currentIndex + amount * 2 - 1);
+    }
+  };
+
+  const scrollToPrevRef = () => {
+    const sizes = getSizes();
+    if (sizes) {
+      /** Calculate number of places to move based on screen size */
+      const amount = Math.floor(sizes.container / sizes.element);
+      /** Calculate current position the array based on location of scroll */
+      const currentIndex = Math.ceil(sizes.position / (sizes.element + 20));
+      scrollToIndex(currentIndex - amount);
+    }
+  };
+
+  return (
+    <section className={style.container}>
+      <div className={style.arrowContainer}>
+        <CarouselArrow direction="left" onClick={scrollToPrevRef} />
+        <Heading title={title} />
+        <CarouselArrow direction="right" onClick={scrollToNextRef} />
+      </div>
+      <div className={style.carouselContainer} ref={carouselRef}>
+        {values.length && children && <div className={style.carousel}>{children(values)}</div>}
+      </div>
+    </section>
+  );
+}

--- a/src/common/hooks/useRefMap.ts
+++ b/src/common/hooks/useRefMap.ts
@@ -1,0 +1,31 @@
+import { createRef, useMemo, useState } from 'react';
+
+export interface IRefObject<T, K> {
+  value: T;
+  ref: React.RefObject<K>;
+}
+
+const createRefs = <K, T>(values: T[]): Array<IRefObject<T, K>> => {
+  return values.map((value) => ({
+    value,
+    ref: createRef<K>(),
+  }));
+};
+
+/**
+ * Creates a list of refs for a list of objects or primitives.
+ */
+export const useRefMap = <K, T>(values: T[]): [Array<IRefObject<T, K>>, (values: T[]) => void] => {
+  /** Create initalRefs only once */
+  const initialRefs = useMemo(() => createRefs<K, T>(values), []);
+
+  /** Set ref objects to state, so they are updated on change */
+  const [refObjects, setRefObjects] = useState(initialRefs);
+
+  const updateRefObjects = (newValues: T[]) => {
+    const newRefObjects = createRefs<K, T>(newValues);
+    setRefObjects(newRefObjects);
+  };
+
+  return [refObjects, updateRefObjects];
+};

--- a/src/frontpage/components/Offline/OfflineCarousel.tsx
+++ b/src/frontpage/components/Offline/OfflineCarousel.tsx
@@ -1,22 +1,22 @@
 import React from 'react';
 
+import { IRefObject } from 'common/hooks/useRefMap';
 import { IOfflineIssue } from 'frontpage/models/Offline';
 
-import { IOfflineRef } from './index';
 import style from './offline.less';
 
 export interface IProps {
-  offlines: IOfflineRef[];
+  offlines: Array<IRefObject<IOfflineIssue, HTMLDivElement>>;
 }
 
 const IMAGE_SUFFIX = '.thumb.png';
 
 const OfflineCarousel = ({ offlines }: IProps) => (
-  <div className={style.carousel}>
+  <>
     {offlines.map((offline) => (
-      <CarouselItem key={offline.issue.id} offline={offline.issue} scrollRef={offline.ref} />
+      <CarouselItem key={offline.value.id} offline={offline.value} scrollRef={offline.ref} />
     ))}
-  </div>
+  </>
 );
 
 export interface ICarouselItemProps {

--- a/src/frontpage/components/Offline/index.tsx
+++ b/src/frontpage/components/Offline/index.tsx
@@ -1,13 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import Heading from 'common/components/Heading';
+import { Carousel } from 'common/components/Carousel';
 import { usePrefetch } from 'common/hooks/usePrefetch';
 import { PrefetchKey } from 'common/utils/PrefetchState';
 import { getOfflines, getRemainingOfflines } from 'frontpage/api/offline';
 import { IOfflineIssue } from 'frontpage/models/Offline';
 
-import CarouselArrow from './CarouselArrow';
-import style from './offline.less';
 import OfflineCarousel from './OfflineCarousel';
 
 export interface IProps {}
@@ -19,87 +17,25 @@ export interface IState {
   page: number;
 }
 
-export interface IOfflineRef {
-  issue: IOfflineIssue;
-  ref: React.RefObject<HTMLDivElement>;
-}
-
-const createOfflineRefs = (offlines: IOfflineIssue[]): IOfflineRef[] => {
-  return offlines.map((issue) => ({
-    issue,
-    ref: React.createRef<HTMLDivElement>(),
-  }));
-};
-
 export const Offline = ({  }: IProps) => {
   const prefetch = usePrefetch(PrefetchKey.OFFLINES, async () => {
     const { results } = await getOfflines(1);
     return results;
   });
-  const initialOfflines = prefetch && prefetch.length ? createOfflineRefs(prefetch) : [];
-
-  const [offlines, setOfflines] = useState<IOfflineRef[]>(initialOfflines);
-  const carouselRef = useRef<HTMLDivElement>(null);
-
-  const getSizes = () => {
-    if (offlines.length) {
-      const [first] = offlines;
-      if (first.ref.current && carouselRef.current) {
-        return {
-          element: first.ref.current.scrollWidth,
-          container: carouselRef.current.clientWidth,
-          position: carouselRef.current.scrollLeft,
-        };
-      }
-    }
-    return null;
-  };
-
-  const scrollToIndex = (index: number) => {
-    /** Bound the index by the upper and lower limits of the array */
-    const boundedIndex = index < 0 ? 0 : index >= offlines.length ? offlines.length - 1 : index;
-    const target = offlines[boundedIndex];
-    const ref = target ? target.ref.current : null;
-    if (ref) {
-      ref.scrollIntoView({ behavior: 'smooth', inline: 'nearest' });
-    }
-  };
-
-  const scrollToNextRef = () => {
-    const sizes = getSizes();
-    if (sizes) {
-      /** Calculate number of places to move based on screen size */
-      const amount = Math.floor(sizes.container / sizes.element);
-      /** Calculate current position the array based on location of scroll */
-      const currentIndex = Math.floor(sizes.position / (sizes.element + 20));
-      scrollToIndex(currentIndex + amount * 2 - 1);
-    }
-  };
-
-  const scrollToPrevRef = () => {
-    const sizes = getSizes();
-    if (sizes) {
-      /** Calculate number of places to move based on screen size */
-      const amount = Math.floor(sizes.container / sizes.element);
-      /** Calculate current position the array based on location of scroll */
-      const currentIndex = Math.ceil(sizes.position / (sizes.element + 20));
-      scrollToIndex(currentIndex - amount);
-    }
-  };
+  const initialOfflines = prefetch && prefetch.length ? prefetch : [];
+  const [offlines, setOfflines] = useState(initialOfflines);
 
   /** Get the first batch of Offlines for feast loading */
   const fetchInitial = async () => {
     const { results } = await getOfflines(1);
-    const offlineRefs = createOfflineRefs(results);
-    setOfflines(offlineRefs);
+    setOfflines(results);
     fetchRemaining();
   };
 
   /** Get all the remaining Offlines to fill out the list */
   const fetchRemaining = async () => {
     const remaining = await getRemainingOfflines();
-    const offlineRefs = createOfflineRefs(remaining);
-    setOfflines(offlineRefs);
+    setOfflines(remaining);
   };
 
   /** Fetch offlines on first mount */
@@ -108,16 +44,9 @@ export const Offline = ({  }: IProps) => {
   }, []);
 
   return (
-    <section className={style.container}>
-      <div className={style.arrowContainer}>
-        <CarouselArrow direction="left" onClick={scrollToPrevRef} />
-        <Heading title="Offline" />
-        <CarouselArrow direction="right" onClick={scrollToNextRef} />
-      </div>
-      <div className={style.carouselContainer} ref={carouselRef}>
-        {offlines.length && <OfflineCarousel offlines={offlines} />}
-      </div>
-    </section>
+    <Carousel values={offlines} title="Offline">
+      {(offlineRefs) => <OfflineCarousel offlines={offlineRefs} />}
+    </Carousel>
   );
 };
 

--- a/src/frontpage/components/Offline/offline.less
+++ b/src/frontpage/components/Offline/offline.less
@@ -2,36 +2,6 @@
 @import '~common/less/colors.less';
 @import '~common/less/constants.less';
 
-.container {
-  margin-top: 40px;
-  width: 100%;
-}
-
-.carouselContainer {
-  display: flex;
-  scroll-snap-type: x mandatory;
-  overflow-x: scroll;
-  scrollbar-width: none;
-  &::-webkit-scrollbar {
-    display: none;
-  }
-}
-
-.carouselArrow {
-  align-self: center;
-  background: none;
-  font-size: 20px;
-  color: @lightGray;
-  & :hover {
-    color: @gray;
-    cursor: pointer;
-  }
-}
-
-.carousel {
-  display: flex;
-}
-
 .carouselItem {
   .owCard();
   transition: 1s ease-in 0.2s;
@@ -60,11 +30,4 @@
   &:not(:last-child) {
     margin-right: 20px;
   }
-}
-
-.arrowContainer {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  justify-items: center;
-  margin-bottom: 20px;
 }


### PR DESCRIPTION
Carousels are nice, we might have many uses for them.

This PR splits the Carousel component for Offline out into its' own reusable component.

Also reduces the complexity of the Offline module by at lot.