### PR TITLE
Add endless scrolling to user search in profile

### DIFF
--- a/src/common/hooks/useIntersection.ts
+++ b/src/common/hooks/useIntersection.ts
@@ -18,9 +18,9 @@ export const useIntersection = (options?: IntersectionObserverInit): [Entry | nu
         observer.observe(targetRef.current);
       }
       return () => observer.disconnect();
-    } else {
-      setCount((oldCount) => oldCount + 1);
     }
+    setCount((oldCount) => oldCount + 1);
+    return
   }, [targetRef.current]);
   return [observerEntry, targetRef];
 };

--- a/src/common/hooks/useIntersection.ts
+++ b/src/common/hooks/useIntersection.ts
@@ -1,0 +1,26 @@
+import { RefObject, useEffect, useRef, useState } from 'react';
+
+export type Ref = RefObject<HTMLDivElement>;
+export type Entry = IntersectionObserverEntry;
+
+export const useIntersection = (options?: IntersectionObserverInit): [Entry | null, Ref] => {
+  const targetRef = useRef<HTMLDivElement>(null);
+  const [observerEntry, setEntry] = useState<Entry | null>(null);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (count !== 0) {
+      const observer = new IntersectionObserver((entries) => {
+        const [firstEntry] = entries;
+        setEntry(firstEntry);
+      }, options);
+      if (targetRef.current) {
+        observer.observe(targetRef.current);
+      }
+      return () => observer.disconnect();
+    } else {
+      setCount((oldCount) => oldCount + 1);
+    }
+  }, [targetRef.current]);
+  return [observerEntry, targetRef];
+};

--- a/src/common/hooks/useIntersection.ts
+++ b/src/common/hooks/useIntersection.ts
@@ -20,7 +20,7 @@ export const useIntersection = (options?: IntersectionObserverInit): [Entry | nu
       return () => observer.disconnect();
     }
     setCount((oldCount) => oldCount + 1);
-    return
+    return;
   }, [targetRef.current]);
   return [observerEntry, targetRef];
 };

--- a/src/profile/api/search.ts
+++ b/src/profile/api/search.ts
@@ -4,7 +4,7 @@ import { get, IAPIData, IBaseAPIParameters } from 'common/utils/api';
 import { IPublicProfile } from '../models/User';
 
 export interface IUserSearchParameters extends IBaseAPIParameters {
-  search: string;
+  search?: string;
   group?: string;
   range: [number, number];
 }
@@ -12,11 +12,28 @@ export interface IUserSearchParameters extends IBaseAPIParameters {
 const API_URL = '/api/v1/profile/search/';
 
 export const searchUsers = async (params: IUserSearchParameters, user: IAuthUser) => {
-  const { results = [] } = await get<IAPIData<IPublicProfile>>(API_URL, { format: 'json', ...params }, { user });
-  return results;
+  const request = await get<IAPIData<IPublicProfile>>(API_URL, { format: 'json', ...params }, { user });
+  return request;
 };
 
 export const getPublicProfile = async (profileId: number, user: IAuthUser) => {
   const profile = await get<IPublicProfile>(API_URL + profileId, { format: 'json' }, { user });
   return profile;
 };
+
+export async function* getProfilesIterator({ search, group, range }: IUserSearchParameters, user: IAuthUser) {
+  /** Fetch the first page of profiles, to set the count and init the generator loop */
+  const { count, results: initialProfiles } = await searchUsers({ search, group, range, page: 1 }, user);
+  yield initialProfiles;
+
+  /** Loop through and yield the remaining pages of profiles one by one */
+  const pageSize = 10;
+  const startPage = 2;
+  const pageCount = Math.ceil(count / pageSize);
+  for (let i = startPage; i < pageCount; i++) {
+    const { results: nextProfiles } = await searchUsers({ search, group, range, page: i }, user);
+    yield nextProfiles;
+  }
+
+  return;
+}

--- a/src/profile/components/Search/ProfileSmall.tsx
+++ b/src/profile/components/Search/ProfileSmall.tsx
@@ -5,9 +5,9 @@ import DEFAULT_USER_IMAGE from 'common/img/profile/user.png';
 import { IPublicProfile } from '../../models/User';
 import style from './search.less';
 
-class ProfileSmall extends React.Component<{ user: IPublicProfile }> {
+class ProfileSmall extends React.Component<{ profile: IPublicProfile }> {
   public render() {
-    const { first_name, last_name, phone_number, online_mail, image, email } = this.props.user;
+    const { first_name, last_name, phone_number, online_mail, image, email } = this.props.profile;
     const name = `${first_name} ${last_name}`;
     const imgSrc = image || DEFAULT_USER_IMAGE;
     const displayEmail = online_mail ? `${online_mail}@online.ntnu.no` : email;

--- a/src/profile/components/Search/Users.tsx
+++ b/src/profile/components/Search/Users.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
-import { Button } from 'core/components/errors/NotAuthenticated/Button';
+import { useIntersection } from 'common/hooks/useIntersection';
 import { Link } from 'core/components/Router';
 import { ProfileSearchContext } from 'profile/providers/SearchFilter';
 
@@ -10,21 +10,33 @@ import style from './search.less';
 
 export const Users = () => {
   const { users, nextPage } = useContext(ProfileSearchContext);
-  if (users.length === 0) {
-    return <h3 className={style.marginTop}>Finner ingen brukere med disse filterene</h3>;
-  }
+  const [entry, targetRef] = useIntersection();
+  const [count, setCount] = useState(0); // TODO: Implement inside useIntersection somehow.
+
+  useEffect(() => {
+    if (entry && entry.isIntersecting && count !== 0) {
+      nextPage();
+    }
+    // TODO: Figure out why this is needed, and implement it inside the hook.
+    setCount((stateCount) => stateCount + 1);
+  }, [entry]);
+
   return (
     <>
-      <div className={style.smallProfileGrid}>
-        {users.map((user) => (
-          <Link to={routes.public + `/${user.id}`}>
-            <ProfileSmall user={user} key={user.username} />
-          </Link>
-        ))}
-      </div>
-      <div className={style.marginTop}>
-        <Button onClick={nextPage}>Last inn mer</Button>
-      </div>
+      {!users.length ? (
+        <div className={style.marginTop}>
+          <h3>Finner ingen brukere med disse filterene</h3>
+        </div>
+      ) : (
+        <div className={style.smallProfileGrid}>
+          {users.map((user) => (
+            <Link to={routes.public + `/${user.id}`} key={`${user.id} ${user.first_name} ${user.last_name}`}>
+              <ProfileSmall user={user} key={user.username} />
+            </Link>
+          ))}
+        </div>
+      )}
+      <div ref={targetRef} />
     </>
   );
 };

--- a/src/profile/components/Search/Users.tsx
+++ b/src/profile/components/Search/Users.tsx
@@ -9,7 +9,7 @@ import ProfileSmall from './ProfileSmall';
 import style from './search.less';
 
 export const Users = () => {
-  const { users, nextPage } = useContext(ProfileSearchContext);
+  const { profiles, nextPage } = useContext(ProfileSearchContext);
   const [entry, targetRef] = useIntersection();
   const [count, setCount] = useState(0); // TODO: Implement inside useIntersection somehow.
 
@@ -23,15 +23,15 @@ export const Users = () => {
 
   return (
     <>
-      {!users.length ? (
+      {!profiles.length ? (
         <div className={style.marginTop}>
           <h3>Finner ingen brukere med disse filterene</h3>
         </div>
       ) : (
         <div className={style.smallProfileGrid}>
-          {users.map((user) => (
-            <Link to={routes.public + `/${user.id}`} key={`${user.id} ${user.first_name} ${user.last_name}`}>
-              <ProfileSmall user={user} key={user.username} />
+          {profiles.map((profile) => (
+            <Link to={routes.public + `/${profile.id}`} key={profile.id}>
+              <ProfileSmall profile={profile} />
             </Link>
           ))}
         </div>


### PR DESCRIPTION
Uses an intersection observer in a hook to determine if the bottom of the list of users in visible in the view-port.
If it is, the next page of users is fetched and added.

The intersection observer is also split out into a hook, to be reused for other things.