### PR TITLE
Enforce 'no-any' rule for TypeScript

### DIFF
--- a/src/articles/api/index.ts
+++ b/src/articles/api/index.ts
@@ -4,6 +4,6 @@ import { IArticle } from '../models/Article';
 const API_URL = '/api/v1/articles/';
 
 export const getArticles = async (): Promise<IArticle[]> => {
-  const data: IAPIData<IArticle> = await get(API_URL, { format: 'json' });
+  const data = await get<IAPIData<IArticle>>(API_URL, { format: 'json' });
   return data.results;
 };

--- a/src/career/api/index.ts
+++ b/src/career/api/index.ts
@@ -13,7 +13,7 @@ export type FilterJobs = [
 ];
 
 export const getCareerOpportunities = async (): Promise<FilterJobs> => {
-  const { results }: IAPIData<ICareerOpportunity> = await get(API_URL, { format: 'json' });
+  const { results } = await get<IAPIData<ICareerOpportunity>>(API_URL, { format: 'json' });
   return configureFilters(results);
 };
 

--- a/src/career/components/JobListItem.tsx
+++ b/src/career/components/JobListItem.tsx
@@ -8,7 +8,7 @@ import { formatDeadline } from './JobDetails';
 // Accepts a list of locations and returns a comma-separated list of locations
 // with 'og' inserted before the last element, and 'Ikke spesifisert' if no
 // locations have been specified.
-export const formatLocations = (locations: any) => {
+export const formatLocations = (locations: string[]) => {
   if (locations.length >= 2) {
     // If we have more than 2 elements, return a comma-separated list.
     return `${locations.slice(0, -1).join(', ')} og ${locations[locations.length - 1]}`;

--- a/src/common/components/Panes/FourSplitPane.tsx
+++ b/src/common/components/Panes/FourSplitPane.tsx
@@ -1,6 +1,6 @@
-import React, { Props } from 'react';
+import React, { FC } from 'react';
 import style from './profileCommon.less';
 
-export const FourSplitPane = ({ children }: Props<any>) => <div className={style.fourSplitPane}>{children}</div>;
+export const FourSplitPane: FC = ({ children }) => <div className={style.fourSplitPane}>{children}</div>;
 
 export default FourSplitPane;

--- a/src/common/components/Panes/SplitPane.tsx
+++ b/src/common/components/Panes/SplitPane.tsx
@@ -1,6 +1,6 @@
-import React, { Props } from 'react';
+import React, { FC } from 'react';
 import style from './profileCommon.less';
 
-export const SplitPane = ({ children }: Props<any>) => <div className={style.splitPane}>{children}</div>;
+export const SplitPane: FC = ({ children }) => <div className={style.splitPane}>{children}</div>;
 
 export default SplitPane;

--- a/src/common/providers/Prefetched.tsx
+++ b/src/common/providers/Prefetched.tsx
@@ -1,10 +1,10 @@
-import PrefetchState from 'common/utils/PrefetchState';
+import PrefetchState, { PrefetchKey } from 'common/utils/PrefetchState';
 import React, { Component, createContext } from 'react';
 
 export interface IPreFetchState {
-  queue: (fetcher: () => any, key: string) => void;
-  get: (key: any) => any;
-  has: (key: any) => boolean;
+  queue: (fetcher: () => Promise<{}>, key: PrefetchKey) => void;
+  get: (key: PrefetchKey) => {};
+  has: (key: PrefetchKey) => boolean;
 }
 
 export interface IProps {
@@ -12,13 +12,13 @@ export interface IProps {
 }
 
 const INITIAL_STATE: IPreFetchState = {
-  queue: (_: (props: any) => any) => {
+  queue: (_: (props: {}) => Promise<{}>) => {
     throw new Error('Queue method from initial state was not overwritten');
   },
-  get: (_: string) => {
+  get: (_: PrefetchKey) => {
     throw new Error('Get method from initial state was not overwritten');
   },
-  has: (_: any) => {
+  has: (_: PrefetchKey) => {
     throw new Error('Has method from initial state was not overwritten');
   },
 };

--- a/src/common/utils/PrefetchState.ts
+++ b/src/common/utils/PrefetchState.ts
@@ -10,25 +10,26 @@ export enum PrefetchKey {
   OFFLINES = 'OFFLINES',
 }
 
-export type Fetcher = () => Promise<any>;
+export type Fetcher = () => Promise<{}>;
 
 export default class PrefetchState {
-  public keys: string[] = [];
-  public fetchers: Array<Promise<any>> = [];
+  public keys: PrefetchKey[] = [];
+  public fetchers: Array<Promise<{}>> = [];
+  public values: Array<{}> = [];
 
-  public queue = (fetcher: Fetcher, key: string) => {
+  public queue = (fetcher: Fetcher, key: PrefetchKey) => {
     if (__SERVER__) {
       this.fetchers.push(fetcher());
       this.keys.push(key);
     }
   };
 
-  public get = (key: string) => {
+  public get = (key: PrefetchKey) => {
     const index = this.keys.indexOf(key);
     return this.fetchers[index];
   };
 
-  public has = (key: string): boolean => {
+  public has = (key: PrefetchKey): boolean => {
     return this.keys.indexOf(key) >= 0;
   };
 
@@ -36,15 +37,15 @@ export default class PrefetchState {
     await Promise.all(this.fetchers);
     this.fetchers.map((fetcher, i) =>
       fetcher.then((value) => {
-        this.fetchers[i] = value;
+        this.values[i] = value;
       })
     );
   };
 
   public getData = () => {
-    const data: { [key: string]: any } = {};
+    const data: { [key: string]: {} } = {};
     for (let i = 0; i < this.keys.length; i++) {
-      data[this.keys[i]] = this.fetchers[i];
+      data[this.keys[i]] = this.values[i];
     }
     return data;
   };
@@ -55,7 +56,7 @@ export default class PrefetchState {
     }
     const data = JSON.parse(window.__PREFETCHED_STATE__);
     Object.keys(data).forEach((key) => {
-      this.keys.push(key);
+      this.keys.push(key as PrefetchKey);
       this.fetchers.push(data[key]);
     });
   };

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -55,7 +55,7 @@ const performRequest = async (query: string, parameters: object = {}, options: I
  * @param {string} query API endpoint URL
  * @returns {Promise<any>} API data
  */
-export const get = async (query: string, parameters: object = {}, options: IRequestOptions = {}): Promise<any> => {
+export const get = async <T>(query: string, parameters: object = {}, options: IRequestOptions = {}): Promise<T> => {
   // const request = makeRequest(query, parameters, options);
   return performRequest(query, parameters, options);
 };
@@ -72,12 +72,12 @@ export async function getAllPages<T>(
 ): Promise<T[]> {
   const { page = 1, page_size = 80 } = parameters;
   /** Get the amount of objects to get in total by fetching a single object */
-  const { count }: IAPIData<T> = await get(query, { ...parameters, page, page_size: 1 }, options);
+  const { count }: IAPIData<T> = await get<IAPIData<T>>(query, { ...parameters, page, page_size: 1 }, options);
   /** Prepare an array with an index for each page which will be fetched */
   const pageNumber = Math.ceil(count / page_size);
   const requestCount = [...Array(pageNumber)];
   /** Initialize the fetches for all the pages at the same time */
-  const requests = requestCount.map((_, i) => get(query, { ...parameters, page: i + 1, page_size }, options));
+  const requests = requestCount.map((_, i) => get<IAPIData<T>>(query, { ...parameters, page: i + 1, page_size }, options));
   /** Await all the fetches to a single array */
   const data: Array<IAPIData<T>> = await Promise.all(requests);
   /** Reduce all results to a single array for all objects in the resource */
@@ -92,12 +92,12 @@ export async function getAllPages<T>(
  * @param {object} parameters
  * @returns {Promise<any>}
  */
-export const post = async (
+export const post = async <T>(
   query: string,
-  data: any,
+  data: T | {},
   parameters: object = {},
   options: IRequestOptions = {}
-): Promise<any> => {
+): Promise<T> => {
   const headers = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
@@ -107,14 +107,14 @@ export const post = async (
   return performRequest(query, parameters, opts);
 };
 
-export interface IPutParams {
+export interface IPutParams <T>{
   query: string;
-  data: any;
+  data: T;
   parameters?: object;
   options?: IRequestOptions;
 }
 
-export const put = async (putParams: IPutParams): Promise<any> => {
+export const put = async <T>(putParams: IPutParams<Partial<T>>): Promise<T> => {
   const { query, data, parameters = {}, options = {} } = putParams;
   const headers = {
     Accept: 'application/json',

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -1,6 +1,6 @@
 import { DOMAIN } from '../constants/endpoints';
 import { __CLIENT__ } from '../constants/environment';
-import { toQueryString } from './queryString';
+import { IQueryObject, toQueryString } from './queryString';
 
 import { IAuthUser } from 'authentication/models/User';
 import { getCache, hasCache, IRequestCacheOptions, setCache } from './requestCache';
@@ -23,13 +23,8 @@ export interface IBaseAPIParameters {
   page?: number;
   format?: 'json' | string;
 }
-/*
-const makeRequest = (query: string, parameters: object = {}, options: RequestInit = {}) => {
-  const queryString = toQueryString(parameters);
-  return new Request(DOMAIN + query + queryString, options);
-};
-*/
-const performRequest = async (query: string, parameters: object = {}, options: IRequestOptions = {}) => {
+
+const performRequest = async (query: string, parameters: IQueryObject = {}, options: IRequestOptions = {}) => {
   const queryString = toQueryString(parameters);
   const { cacheOptions, user, domain, ...restOptions } = options;
   const url = (domain || DOMAIN) + query + queryString;
@@ -55,7 +50,11 @@ const performRequest = async (query: string, parameters: object = {}, options: I
  * @param {string} query API endpoint URL
  * @returns {Promise<any>} API data
  */
-export const get = async <T>(query: string, parameters: object = {}, options: IRequestOptions = {}): Promise<T> => {
+export const get = async <T>(
+  query: string,
+  parameters: IQueryObject = {},
+  options: IRequestOptions = {}
+): Promise<T> => {
   // const request = makeRequest(query, parameters, options);
   return performRequest(query, parameters, options);
 };
@@ -97,7 +96,7 @@ export async function getAllPages<T>(
 export const post = async <T>(
   query: string,
   data: T | {},
-  parameters: object = {},
+  parameters: IQueryObject = {},
   options: IRequestOptions = {}
 ): Promise<T> => {
   const headers = {
@@ -112,7 +111,7 @@ export const post = async <T>(
 export interface IPutParams<T> {
   query: string;
   data: T;
-  parameters?: object;
+  parameters?: IQueryObject;
   options?: IRequestOptions;
 }
 

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -77,7 +77,9 @@ export async function getAllPages<T>(
   const pageNumber = Math.ceil(count / page_size);
   const requestCount = [...Array(pageNumber)];
   /** Initialize the fetches for all the pages at the same time */
-  const requests = requestCount.map((_, i) => get<IAPIData<T>>(query, { ...parameters, page: i + 1, page_size }, options));
+  const requests = requestCount.map((_, i) =>
+    get<IAPIData<T>>(query, { ...parameters, page: i + 1, page_size }, options)
+  );
   /** Await all the fetches to a single array */
   const data: Array<IAPIData<T>> = await Promise.all(requests);
   /** Reduce all results to a single array for all objects in the resource */
@@ -107,7 +109,7 @@ export const post = async <T>(
   return performRequest(query, parameters, opts);
 };
 
-export interface IPutParams <T>{
+export interface IPutParams<T> {
   query: string;
   data: T;
   parameters?: object;

--- a/src/common/utils/prefetch.tsx
+++ b/src/common/utils/prefetch.tsx
@@ -4,7 +4,10 @@ import React from 'react';
 import { PrefetchKey } from './PrefetchState';
 
 export function prefetch(key: PrefetchKey) {
-  return function wrap(WrappedComponent: typeof PrefetchableComponent): {} {
+  // Impossible to type the wrapped component correctly, as it extends the class in a non-OOP way.
+  // Uses 'any', as the types are fairly well enforced when the decorator is used.
+  // tslint:disable-next-line no-any
+  return function wrap(WrappedComponent: typeof PrefetchableComponent): any {
     return class extends React.Component<{}> {
       public static contextType = PreFetchContext;
       public render() {

--- a/src/common/utils/prefetch.tsx
+++ b/src/common/utils/prefetch.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { PrefetchKey } from './PrefetchState';
 
 export function prefetch(key: PrefetchKey) {
-  return function wrap(WrappedComponent: typeof PrefetchableComponent): any {
+  return function wrap(WrappedComponent: typeof PrefetchableComponent): {} {
     return class extends React.Component<{}> {
       public static contextType = PreFetchContext;
       public render() {
@@ -23,12 +23,12 @@ export function prefetch(key: PrefetchKey) {
 }
 
 export interface IPrefetchedComponent {
-  getServerState(props: any): Promise<any>;
+  getServerState(props: {}): Promise<{}>;
 }
 
 /* tslint:disable-next-line */
-export class PrefetchableComponent<P = {}, S = {}, SS = any> extends React.Component<P, S, SS> {
-  public static async getServerState(_: any): Promise<any> {
+export class PrefetchableComponent<P = {}, S = {}, SS = {}> extends React.Component<P, S, SS> {
+  public static async getServerState(_: {}): Promise<{}> {
     throw new Error('Static getServerState method of PrefetchableComponent was not overwritten in implemented class');
   }
 }

--- a/src/common/utils/queryString.ts
+++ b/src/common/utils/queryString.ts
@@ -1,9 +1,15 @@
+export type QueryTypes = string | number | null | undefined;
+
+export interface IQueryObject {
+  [index: string]: QueryTypes | QueryTypes[];
+}
+
 /**
  * TODO: Add validation
  * @param {object} queryObject e.g. {foo: 'bar', hello: 'world'}
  * @return {string} e.g. ?foo=bar&hello=world
  */
-export const toQueryString = (queryObject: any): string => {
+export const toQueryString = (queryObject: IQueryObject): string => {
   const keys = Object.keys(queryObject);
   if (!keys.length) {
     return '';
@@ -13,10 +19,6 @@ export const toQueryString = (queryObject: any): string => {
     .map((key: string) => `${key}=${queryObject[key]}`);
   return `?${queries.join('&')}`;
 };
-
-export interface IQueryObject {
-  [index: string]: string;
-}
 
 /**
  * TODO: Add validation

--- a/src/common/utils/requestCache.ts
+++ b/src/common/utils/requestCache.ts
@@ -11,7 +11,7 @@ const DEFAULT_OPTIONS: IRequestCacheOptions = {
 };
 
 export interface ICache {
-  content: any;
+  content: {};
   expires: number;
 }
 
@@ -46,7 +46,7 @@ export const getCache = ({ url, options = DEFAULT_OPTIONS }: IGetCache): ICacheR
 export interface ISetCache {
   url: string;
   options?: IRequestCacheOptions;
-  content: any;
+  content: {};
 }
 
 export const setCache = ({ url, options = DEFAULT_OPTIONS, content }: ISetCache) => {

--- a/src/contribution/api/repositories.tsx
+++ b/src/contribution/api/repositories.tsx
@@ -1,11 +1,8 @@
-import { get } from '../../common/utils/api';
+import { get, IAPIData } from 'common/utils/api';
+
+import { IRepository } from 'contribution/models/Repository';
 
 export const getRepositories = async () => {
-  try {
-    const data = await get('/api/v1/repositories', { format: 'json' });
-    return data;
-  } catch (err) {
-    /* tslint:disable-next-line: no-console */
-    console.error(err);
-  }
+  const data = await get<IAPIData<IRepository>>('/api/v1/repositories', { format: 'json' });
+  return data;
 };

--- a/src/contribution/components/LanguageSubBar.tsx
+++ b/src/contribution/components/LanguageSubBar.tsx
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React, { Component } from 'react';
+
 import style from '../less/contribution.less';
+import { getLanguageColor } from '../models/Language';
 import { IRepositoryLanguage } from '../models/Repository';
 
 export interface IProps {
@@ -29,39 +31,27 @@ export default class LanguageSubBar extends Component<IProps, {}> {
   }
 
   public render() {
-    const languageColors: any = {
-      JavaScript: '#f1e05a',
-      TypeScript: '#2b7489',
-      CSS: '#563d7c',
-      HTML: '#e34c26',
-      Python: '#3572A5',
-      Makefile: '#427819',
-      Shell: '#89e051',
-    };
-
-    const color = languageColors[this.props.language.type];
-    const sub_style: any = {
+    const color = getLanguageColor(this.props.language.type);
+    const subStyle: React.CSSProperties = {
       backgroundColor: color ? color : 'brown',
       width: (this.props.language.size / this.props.totalLanguageSize) * 100 + '%',
       display: 'flex',
       justifyContent: 'center',
     };
 
-    const borderRadius = 'borderRadius';
-
     // If there is only 1 language, apply borderRadius to both sides
     if (this.props.index === 0 && this.props.numLanguages === 1) {
-      sub_style[borderRadius] = '20px 20px 20px 20px';
+      subStyle.borderRadius = '20px 20px 20px 20px';
       // If language is first, apply borderRadius to left side
     } else if (this.props.index === 0) {
-      sub_style[borderRadius] = '20px 0 0 20px';
+      subStyle.borderRadius = '20px 0 0 20px';
       // If language is last, apply borderRadius to right side
     } else if (this.props.index === this.props.numLanguages - 1) {
-      sub_style[borderRadius] = '0 20px 20px 0';
+      subStyle.borderRadius = '0 20px 20px 0';
     }
 
     return (
-      <div style={sub_style} onMouseOver={this.handleMouseIn} onMouseOut={this.handleMouseOut}>
+      <div style={subStyle} onMouseOver={this.handleMouseIn} onMouseOut={this.handleMouseOut}>
         <div className={classNames(style.toolTip, { [style.active]: this.state.hover })}>{this.props.tooltip}</div>
       </div>
     );

--- a/src/contribution/components/RepositoryList.tsx
+++ b/src/contribution/components/RepositoryList.tsx
@@ -9,10 +9,10 @@ export interface IRepositoryListState {
 }
 
 export default class RepositoryList extends Component<{}, IRepositoryListState> {
-  public readonly state = { repositories: [] } as IRepositoryListState;
+  public readonly state: IRepositoryListState = { repositories: [] };
 
   public async componentDidMount() {
-    const data: any = await getRepositories();
+    const data = await getRepositories();
     this.setState({ repositories: data.results });
   }
 

--- a/src/contribution/models/Language.ts
+++ b/src/contribution/models/Language.ts
@@ -1,0 +1,18 @@
+export const LANGUAGE_COLORS = {
+  JavaScript: '#f1e05a',
+  TypeScript: '#2b7489',
+  CSS: '#563d7c',
+  HTML: '#e34c26',
+  Python: '#3572A5',
+  Makefile: '#427819',
+  Shell: '#89e051',
+  None: '#c4c4c4',
+};
+
+export const getLanguageColor = (language: string) => {
+  if (language in LANGUAGE_COLORS) {
+    return LANGUAGE_COLORS[language as keyof typeof LANGUAGE_COLORS];
+  } else {
+    return LANGUAGE_COLORS.None;
+  }
+};

--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { FC } from 'react';
 import Footer from './components/Footer/index';
 import Header from './components/Header/index';
 import './less/core.less';
 
-const Core = ({ children }: any) => (
+const Core: FC = ({ children }) => (
   <>
     <Header />
     <main>{children}</main>

--- a/src/core/providers/Cookies.tsx
+++ b/src/core/providers/Cookies.tsx
@@ -13,14 +13,14 @@ export interface ICookies {
   eventView: EventView;
 }
 
-const initializeCookies = (inital: { [name: string]: any }): ICookies => ({
+const initializeCookies = (inital: { [name: string]: string | undefined }): ICookies => ({
   ...inital,
   eventView: getEventView(inital.eventView),
 });
 
 export interface IProps {
   children: ReactNode;
-  cookies: { [name: string]: any };
+  cookies: { [name: string]: string | undefined };
 }
 
 export enum CookieActionType {

--- a/src/events/api/events.ts
+++ b/src/events/api/events.ts
@@ -21,7 +21,7 @@ export interface IAPIData<T> {
 const API_URL = '/api/v1/events/';
 
 export const getEvents = async (args?: IEventAPIParameters): Promise<INewEvent[]> => {
-  const data: IAPIData<INewEvent> = await get(API_URL, { format: 'json', ...args });
+  const data = await get<IAPIData<INewEvent>>(API_URL, { format: 'json', ...args });
   return data.results;
 };
 
@@ -31,7 +31,7 @@ export const getAllUserEvents = async (args: IEventAPIParameters, user: IAuthUse
 };
 
 export const getEvent = async (id: number): Promise<INewEvent> => {
-  const event: INewEvent = await get(API_URL + id + '/', { format: 'json' });
+  const event = await get<INewEvent>(API_URL + id + '/', { format: 'json' });
   return event;
 };
 
@@ -43,6 +43,6 @@ export interface IControlledFetch<T> {
 export const controlledGetEvents = (args?: IEventAPIParameters): IControlledFetch<INewEvent> => {
   const controller = new AbortController();
   const signal = controller.signal;
-  const data: Promise<IAPIData<INewEvent>> = get(API_URL, { format: 'json', ...args }, { signal });
+  const data = get<IAPIData<INewEvent>>(API_URL, { format: 'json', ...args }, { signal });
   return { data, controller };
 };

--- a/src/events/models/Event.ts
+++ b/src/events/models/Event.ts
@@ -175,7 +175,7 @@ export interface INewAttendanceEvent {
   max_capacity: number;
   registration_end: string;
   registration_start: string;
-  rule_bundles: any[];
+  rule_bundles: IRuleBundle[];
   unattend_deadline: string;
   waitlist: boolean;
 }

--- a/src/frontpage/api/offline.ts
+++ b/src/frontpage/api/offline.ts
@@ -3,8 +3,8 @@ import { IOfflineIssue } from '../models/Offline';
 
 const API_URL = '/api/v1/offline/';
 
-export const getOfflines = async (page: number = 1): Promise<IAPIData<IOfflineIssue>> => {
-  return await get(API_URL, { format: 'json', page });
+export const getOfflines = async (page: number = 1) => {
+  return await get<IAPIData<IOfflineIssue>>(API_URL, { format: 'json', page });
 };
 
 export const getRemainingOfflines = (): Promise<IOfflineIssue[]> => {

--- a/src/hobbygroups/api/index.ts
+++ b/src/hobbygroups/api/index.ts
@@ -1,13 +1,9 @@
-import { get } from 'common/utils/api';
+import { get, IAPIData } from 'common/utils/api';
+import { IHobbyGroup } from 'hobbygroups/models/HobbyGroup';
 
 const API_URL = '/api/v1/hobbys';
 
 export const getHobbyGroups = async () => {
-  try {
-    const data = await get(API_URL, { format: 'json' });
-    return data;
-  } catch (err) {
-    /* tslint:disable-next-line: no-console */
-    console.error(err);
-  }
+  const data = await get<IAPIData<IHobbyGroup>>(API_URL, { format: 'json' });
+  return data;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ history.listen((location) => ReactGA.pageview(location.pathname));
 const prefetcher = new PrefetchState();
 prefetcher.serialize();
 
-const render = (RootComponent: any) => {
+const render = (RootComponent: React.ComponentClass<{}> | React.StatelessComponent<{}>) => {
   const initialCookies = cookies.getJSON();
   /** Define renderer to use, hydrate if SSR back-end is enabled, render if no back-end */
   const reactRender = __SSR__ ? ReactDOM.hydrate : ReactDOM.render;

--- a/src/profile/api/index.ts
+++ b/src/profile/api/index.ts
@@ -9,13 +9,13 @@ const API_URL = '/api/v1/profile/';
  *
  */
 export const getProfile = async (user: IAuthUser): Promise<IUserProfile> => {
-  const data: IUserProfile = await get(API_URL, { format: 'json' }, { user });
+  const data = await get<IUserProfile>(API_URL, { format: 'json' }, { user });
   return data;
 };
 
 export type PartialProfile = Partial<IUserProfile>;
 
-export const putProfile = async (profileSettings: PartialProfile, user: IAuthUser): Promise<IUserProfile> => {
-  const data = await put({ query: API_URL, data: profileSettings, options: { user } });
+export const putProfile = async (profileSettings: PartialProfile, user: IAuthUser) => {
+  const data = await put<IUserProfile>({ query: API_URL, data: profileSettings, options: { user } });
   return data;
 };

--- a/src/profile/api/notifications.ts
+++ b/src/profile/api/notifications.ts
@@ -16,17 +16,22 @@ export const unsubscribe = async (sub: PushSubscription, user: IAuthUser) => {
   await post(API_URL + '/unsubscribe', json, {}, { user, domain: API_DOMAIN });
 };
 
-export const getAllChannels = async (user: IAuthUser): Promise<IChannel[]> => {
-  const channels = await get(API_URL + '/channels', {}, { user, domain: API_DOMAIN });
+export const getAllChannels = async (user: IAuthUser) => {
+  const channels = await get<IChannel[]>(API_URL + '/channels', {}, { user, domain: API_DOMAIN });
   return channels;
 };
 
-export const getUserChannels = async (user: IAuthUser): Promise<IChannel[]> => {
-  const channels = await get(API_URL + '/user-channels', {}, { user, domain: API_DOMAIN });
+export const getUserChannels = async (user: IAuthUser) => {
+  const channels = await get<IChannel[]>(API_URL + '/user-channels', {}, { user, domain: API_DOMAIN });
   return channels;
 };
 
-export const postUserChannels = async (channelNames: string[], user: IAuthUser): Promise<IChannel[]> => {
-  const channels = await post(API_URL + '/user-channels', { channels: channelNames }, {}, { user, domain: API_DOMAIN });
+export const postUserChannels = async (channelNames: string[], user: IAuthUser) => {
+  const channels = await post<IChannel[]>(
+    API_URL + '/user-channels',
+    { channels: channelNames },
+    {},
+    { user, domain: API_DOMAIN }
+  );
   return channels;
 };

--- a/src/profile/api/penalties.ts
+++ b/src/profile/api/penalties.ts
@@ -11,7 +11,7 @@ const SUSPENSIONS_URL = API_URL + '/suspensions/';
  * @summary Fetch Marks from API.
  */
 export const getMarks = async (user: IAuthUser): Promise<IMark[]> => {
-  const { results }: IAPIData<IMark> = await get(MARKS_URL, { format: 'json' }, { user });
+  const { results } = await get<IAPIData<IMark>>(MARKS_URL, { format: 'json' }, { user });
   return results;
 };
 
@@ -19,6 +19,6 @@ export const getMarks = async (user: IAuthUser): Promise<IMark[]> => {
  * @summary Fetch Suspensions from API.
  */
 export const getSuspensions = async (user: IAuthUser): Promise<ISuspension[]> => {
-  const { results }: IAPIData<ISuspension> = await get(SUSPENSIONS_URL, { format: 'json' }, { user });
+  const { results } = await get<IAPIData<ISuspension>>(SUSPENSIONS_URL, { format: 'json' }, { user });
   return results;
 };

--- a/src/profile/api/privacy.ts
+++ b/src/profile/api/privacy.ts
@@ -7,8 +7,8 @@ const API_URL = '/api/v1/profile/privacy/';
 /**
  * @returns {IPrivacy} Privacy options for a logged in OnlineUser.
  */
-export const getPrivacyOptions = async (user: IAuthUser): Promise<IPrivacy> => {
-  const data = await get(API_URL, { format: 'json' }, { user });
+export const getPrivacyOptions = async (user: IAuthUser) => {
+  const data = await get<IPrivacy>(API_URL, { format: 'json' }, { user });
   return data;
 };
 
@@ -17,7 +17,7 @@ export const getPrivacyOptions = async (user: IAuthUser): Promise<IPrivacy> => {
  * @param {IPrivacy} privacyOptions Changed Privacy options for a user.
  * @returns {IPrivacy} The current state of OnlineUsers Privacy options.
  */
-export const putPrivacyOptions = async (privacyOptions: IPrivacy, user: IAuthUser): Promise<IPrivacy> => {
-  const data = await put({ query: API_URL, data: privacyOptions, options: { user } });
+export const putPrivacyOptions = async (privacyOptions: IPrivacy, user: IAuthUser) => {
+  const data = await put<IPrivacy>({ query: API_URL, data: privacyOptions, options: { user } });
   return data;
 };

--- a/src/profile/api/search.ts
+++ b/src/profile/api/search.ts
@@ -11,12 +11,12 @@ export interface IUserSearchParameters extends IBaseAPIParameters {
 
 const API_URL = '/api/v1/profile/search/';
 
-export const searchUsers = async (params: IUserSearchParameters, user: IAuthUser): Promise<IPublicProfile[]> => {
-  const { results = [] }: IAPIData<IPublicProfile> = await get(API_URL, { format: 'json', ...params }, { user });
+export const searchUsers = async (params: IUserSearchParameters, user: IAuthUser) => {
+  const { results = [] } = await get<IAPIData<IPublicProfile>>(API_URL, { format: 'json', ...params }, { user });
   return results;
 };
 
-export const getPublicProfile = async (profileId: number, user: IAuthUser): Promise<IPublicProfile> => {
-  const profile = await get(API_URL + profileId, { format: 'json' }, { user });
+export const getPublicProfile = async (profileId: number, user: IAuthUser) => {
+  const profile = await get<IPublicProfile>(API_URL + profileId, { format: 'json' }, { user });
   return profile;
 };

--- a/src/profile/components/MainMenu.tsx
+++ b/src/profile/components/MainMenu.tsx
@@ -6,7 +6,7 @@ import { routes } from '../index';
 import style from './mainMenu.less';
 
 export interface IProps {
-  match: Router.match<any>;
+  match: Router.match<{}>;
 }
 
 class MainMenu extends Component<IProps, {}> {

--- a/src/profile/components/Settings/index.tsx
+++ b/src/profile/components/Settings/index.tsx
@@ -42,6 +42,7 @@ const Settings = (_: IProfileProps) => {
 };
 
 interface ISettingsRouteProps extends IRouteProps {
+  // tslint:disable-next-line no-any , they can be anything
   view: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 

--- a/src/profile/components/Statistics/index.tsx
+++ b/src/profile/components/Statistics/index.tsx
@@ -27,6 +27,7 @@ const Settings = () => {
 };
 
 interface ISettingsRouteProps extends IRouteProps {
+  // tslint:disable-next-line no-any , they can be anything
   view: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 

--- a/src/profile/index.tsx
+++ b/src/profile/index.tsx
@@ -44,6 +44,7 @@ export interface IProfileProps<T = {}> {
 }
 
 interface IProfileRouteProps extends IRouteProps {
+  // tslint:disable-next-line no-any , they can be anything
   view: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 

--- a/src/profile/models/SpecialPosition.ts
+++ b/src/profile/models/SpecialPosition.ts
@@ -1,0 +1,4 @@
+export interface ISpecialPosition {
+  since_year: number;
+  position: string;
+}

--- a/src/profile/models/User.ts
+++ b/src/profile/models/User.ts
@@ -1,5 +1,6 @@
 import { FieldOfStudy } from './FieldOfStudy';
 import { IMedal } from './Medal';
+import { ISpecialPosition } from './SpecialPosition';
 
 export type Gender = 'male' | 'female';
 
@@ -18,7 +19,7 @@ interface IBaseProfile {
   github: string | null;
   linkedin: string | null;
   positions: IMedal[];
-  special_positions: any[];
+  special_positions: ISpecialPosition[];
   readonly field_of_study: FieldOfStudy;
   readonly started_date: string;
   readonly compiled: boolean;

--- a/src/resources/api/index.ts
+++ b/src/resources/api/index.ts
@@ -1,8 +1,9 @@
-import { get } from 'common/utils/api';
+import { get, IAPIData } from 'common/utils/api';
+import { IResource } from 'resources/models/Resource';
 
 const API_URL = '/api/v1/resources/';
 
 export const getResources = async () => {
-  const data = await get(API_URL, { format: 'json' });
+  const data = await get<IAPIData<IResource>>(API_URL, { format: 'json' });
   return data;
 };

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
     "object-literal-sort-keys": false,
     "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case", "allow-snake-case"],
     "jsx-no-lambda": false,
-    "jsx-boolean-value": false
+    "jsx-boolean-value": false,
+    "no-any": true
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Enforce that no 'any' types are used unless the developer specifically disables it.

We use TypeScript to add types to our code. Allowing 'any' makes leaks possible.