### PR TITLE
Rename IImage to ResponsiveImage

### DIFF
--- a/src/articles/models/Article.ts
+++ b/src/articles/models/Article.ts
@@ -1,9 +1,9 @@
-import IImage from 'common/models/Image';
+import IResponsiveImage from 'common/models/ResponsiveImage';
 
 export interface IArticle {
   articleUrl: string;
   heading: string;
-  image: IImage;
+  image: IResponsiveImage;
   ingress: string;
   absolute_url: string;
   ingress_short: string;

--- a/src/common/components/ResponsiveImage/index.tsx
+++ b/src/common/components/ResponsiveImage/index.tsx
@@ -1,13 +1,13 @@
 import React, { ImgHTMLAttributes } from 'react';
 import { DOMAIN } from '../../constants/endpoints';
-import IImage, { IImageSizes } from '../../models/Image';
+import IResponsiveImage, { IResponsiveImageSizes } from '../../models/ResponsiveImage';
 
 export interface IProps extends ImgHTMLAttributes<HTMLImageElement> {
-  image: IImage;
-  size: keyof IImageSizes;
+  image: IResponsiveImage;
+  size: keyof IResponsiveImageSizes;
 }
 
-const ResponsiveImage = ({ image, size, alt, ...props }: IProps) => {
+export const ResponsiveImage = ({ image, size, alt, ...props }: IProps) => {
   const defaultImage = image[size];
   const altText = alt || image.name;
   return <img {...props} src={DOMAIN + defaultImage} alt={altText} />;

--- a/src/common/models/ResponsiveImage.ts
+++ b/src/common/models/ResponsiveImage.ts
@@ -1,4 +1,4 @@
-export default interface IImage extends IImageSizes {
+export default interface IResponsiveImage extends IResponsiveImageSizes {
   id: number;
   name: string;
   timestamp: string;
@@ -7,7 +7,7 @@ export default interface IImage extends IImageSizes {
   photographer: string;
 }
 
-export interface IImageSizes {
+export interface IResponsiveImageSizes {
   thumb: string;
   original: string;
   wide: string;
@@ -17,7 +17,7 @@ export interface IImageSizes {
   xs: string;
 }
 
-export const DEFAULT_EVENT_IMAGE: IImage = {
+export const DEFAULT_EVENT_IMAGE: IResponsiveImage = {
   id: 95,
   name: 'Generisk arrangementsbilde',
   timestamp: '2016-10-16T15:26:40.184370+02:00',

--- a/src/core/models/Company.ts
+++ b/src/core/models/Company.ts
@@ -1,11 +1,11 @@
-import IImage from 'common/models/Image';
+import IResponsiveImage from 'common/models/ResponsiveImage';
 
 export interface ICompany {
   readonly id: number;
   readonly name: string;
   readonly short_description: string; // TextField model?
   readonly long_description: string; // TextField model?
-  readonly image: IImage; // Image, or StaticContent model?
+  readonly image: IResponsiveImage; // Image, or StaticContent model?
   readonly site: string; // URL model?
   readonly email_address: string; // Email model?
   readonly phone_number: string; // Phone model?

--- a/src/core/models/Company.ts
+++ b/src/core/models/Company.ts
@@ -3,10 +3,10 @@ import IResponsiveImage from 'common/models/ResponsiveImage';
 export interface ICompany {
   readonly id: number;
   readonly name: string;
-  readonly short_description: string; // TextField model?
-  readonly long_description: string; // TextField model?
-  readonly image: IResponsiveImage; // Image, or StaticContent model?
-  readonly site: string; // URL model?
-  readonly email_address: string; // Email model?
-  readonly phone_number: string; // Phone model?
+  readonly short_description: string;
+  readonly long_description: string;
+  readonly image: IResponsiveImage;
+  readonly site: string;
+  readonly email_address: string;
+  readonly phone_number: string;
 }

--- a/src/events/components/EventImage.tsx
+++ b/src/events/components/EventImage.tsx
@@ -1,12 +1,12 @@
 import ResponsiveImage from 'common/components/ResponsiveImage';
-import IImage, { DEFAULT_EVENT_IMAGE, IImageSizes } from 'common/models/Image';
+import IResponsiveImage, { DEFAULT_EVENT_IMAGE, IResponsiveImageSizes } from 'common/models/ResponsiveImage';
 import React, { ImgHTMLAttributes } from 'react';
 import { ICompanyEvent } from '../models/Event';
 
 export interface IProps extends ImgHTMLAttributes<HTMLImageElement> {
-  image: IImage | null;
+  image: IResponsiveImage | null;
   companyEvents: ICompanyEvent[];
-  size: keyof IImageSizes;
+  size: keyof IResponsiveImageSizes;
 }
 
 const EventImage = ({ image, companyEvents: [companyEvent], ...props }: IProps) => {

--- a/src/events/models/Event.ts
+++ b/src/events/models/Event.ts
@@ -1,4 +1,4 @@
-import IImage, { DEFAULT_EVENT_IMAGE } from 'common/models/Image';
+import IResponsiveImage, { DEFAULT_EVENT_IMAGE } from 'common/models/ResponsiveImage';
 import { ICompany } from 'core/models/Company';
 import { IExtra } from 'events/models/Extras';
 import { IRuleBundle } from 'events/models/RuleBundles';
@@ -142,7 +142,7 @@ export interface IEvent {
   event_start: string;
   event_type: EventTypeEnum;
   id: number;
-  image: IImage | null;
+  image: IResponsiveImage | null;
   ingress: string;
   ingress_short: string;
   location: string;

--- a/src/profile/models/Orders.ts
+++ b/src/profile/models/Orders.ts
@@ -16,8 +16,7 @@ export interface IStoreItem {
   name: string;
   price: number;
   description: string | null;
-  /** removed to make mocking more effective. Not actually optional. */
-  image?: IResponsiveImage;
+  image: IResponsiveImage;
   category: IStoreItemCategory;
 }
 

--- a/src/profile/models/Orders.ts
+++ b/src/profile/models/Orders.ts
@@ -1,4 +1,4 @@
-import IImage from 'common/models/Image';
+import IResponsiveImage from 'common/models/ResponsiveImage';
 
 export interface IOrderLine {
   paid: boolean;
@@ -17,7 +17,7 @@ export interface IStoreItem {
   price: number;
   description: string | null;
   /** removed to make mocking more effective. Not actually optional. */
-  image?: IImage;
+  image?: IResponsiveImage;
   category: IStoreItemCategory;
 }
 


### PR DESCRIPTION
Yet another poor choice made in that start of this project.
`IImage` should have been named `IResponsiveImage` from the start, but I somehow got that wrong?

Aslo fixes some related type comments for `Company` and `Order`