### PR TITLE
Responsive Responsive Images

### DIFF
--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -27,7 +27,7 @@ const JobDetails = (props: ICareerOpportunity) => (
       <div>
         <div className={style.company}>
           <Link className={style.companyImage} to={`/company/${props.company.id}`}>
-            <ResponsiveImage image={props.company.image} size="lg" alt={props.company.name} />
+            <ResponsiveImage image={props.company.image} size="lg" alt={props.company.name} type="company" />
           </Link>
           <div className={style.companyDescriptionBox}>
             <Link className={style.companyDescriptionTitle} to={`/company/${props.company.id}`}>

--- a/src/career/components/JobListItem.tsx
+++ b/src/career/components/JobListItem.tsx
@@ -24,7 +24,7 @@ export const formatLocations = (locations: string[]) => {
 const JobListItem = ({ location, deadline, company, title, ingress, id, employment }: ICareerOpportunity) => (
   <div className={style.job}>
     <Link to={`/career/${id}`}>
-      <ResponsiveImage image={company.image} size="md" alt="Firmalogo" />
+      <ResponsiveImage image={company.image} size="md" alt="Firmalogo" type="company" />
     </Link>
     <div className={style.jobInfo}>
       <Link to={`/career/${id}`}>

--- a/src/common/components/ResponsiveImage/index.tsx
+++ b/src/common/components/ResponsiveImage/index.tsx
@@ -1,16 +1,88 @@
-import React, { ImgHTMLAttributes } from 'react';
+import React, { FC, ImgHTMLAttributes, useEffect, useState } from 'react';
+
+import { useBoundingRect } from 'common/hooks/useBoundingRect';
+import { getKeys } from 'common/utils/tsHacks';
+
 import { DOMAIN } from '../../constants/endpoints';
-import IResponsiveImage, { IResponsiveImageSizes } from '../../models/ResponsiveImage';
+import IResponsiveImage, {
+  IMAGE_DIMENTIONS,
+  IResponsiveImageSizes,
+  ResponsiveImageTypes,
+} from '../../models/ResponsiveImage';
+
+export type ImageType = ResponsiveImageTypes;
+export type ImageSizes = IResponsiveImageSizes;
+export type ImageSize = keyof ImageSizes;
 
 export interface IProps extends ImgHTMLAttributes<HTMLImageElement> {
   image: IResponsiveImage;
-  size: keyof IResponsiveImageSizes;
+  size: ImageSize;
+  type: ImageType;
 }
 
-export const ResponsiveImage = ({ image, size, alt, ...props }: IProps) => {
-  const defaultImage = image[size];
+/**
+ * @summary Get the key types of images sorted by width.
+ * @example ['xs', 'sm', 'md', 'lg']
+ * @param {ImageType} type
+ */
+const getSortedDimentionKeys = (type: ImageType) => {
+  return getKeys(IMAGE_DIMENTIONS[type])
+    .sort((a, b) => {
+      const [aWidth] = IMAGE_DIMENTIONS[type][a];
+      const [bWidth] = IMAGE_DIMENTIONS[type][b];
+      return aWidth - bWidth;
+    })
+    .filter((t) => t !== 'wide'); // Filter wide because it is unstable, and just mimicks 'lg'.
+};
+
+/**
+ * @summary Get the most fitting image version to display on screen based on the client screen/pixel size.
+ * @param {ResponsiveImageTypes} type
+ * @param {number} displayWidth The actual width of the displayed image in real pixel in the screen.
+ * @param {ImageSize} currentSize The default/currently displayed size. Resolution should ne be downgraded.
+ */
+const getOptimalImageSize = (type: ImageType, displayWidth: number, currentSize: ImageSize): ImageSize => {
+  const dimentions = IMAGE_DIMENTIONS[type];
+  const keys = getSortedDimentionKeys(type);
+
+  /** Flag if the compared sizes are larger than the currently displayes size */
+  let passedCurrent = false;
+
+  for (let i = 0; i < keys.length - 1; i++) {
+    /** Mark current size as larger than current size */
+    if (keys[i] === currentSize) {
+      passedCurrent = true;
+    }
+
+    /** Find most fitting image size depending on currently displayed size in DOM */
+    const [currentWidth] = dimentions[keys[i]];
+    const [nextWidth] = dimentions[keys[i + 1]];
+    if (passedCurrent && displayWidth > currentWidth && displayWidth <= nextWidth) {
+      return keys[i];
+    }
+  }
+
+  /** If no fitting alternative is found, use the supplied default */
+  return currentSize;
+};
+
+export const ResponsiveImage: FC<IProps> = ({ image, size, alt, type, ...props }) => {
+  const [responsiveSize, setResponsiveSize] = useState<ImageSize>(size);
+  const [ref, boundingRect] = useBoundingRect<HTMLImageElement>();
+
+  useEffect(() => {
+    if (boundingRect) {
+      /** Calculate real pixel size based on image size in the DOM */
+      const width = boundingRect.width * window.devicePixelRatio;
+      const optimalSize = getOptimalImageSize(type, width, size);
+      setResponsiveSize(optimalSize);
+    }
+  }, [boundingRect]);
+
+  const defaultImage = image[responsiveSize];
   const altText = alt || image.name;
-  return <img {...props} src={DOMAIN + defaultImage} alt={altText} />;
+
+  return <img {...props} ref={ref} src={DOMAIN + defaultImage} alt={altText} />;
 };
 
 export default ResponsiveImage;

--- a/src/common/components/ResponsiveImage/index.tsx
+++ b/src/common/components/ResponsiveImage/index.tsx
@@ -1,14 +1,13 @@
 import React, { FC, ImgHTMLAttributes, useEffect, useState } from 'react';
 
+import { DOMAIN } from 'common/constants/endpoints';
 import { useBoundingRect } from 'common/hooks/useBoundingRect';
-import { getKeys } from 'common/utils/tsHacks';
-
-import { DOMAIN } from '../../constants/endpoints';
 import IResponsiveImage, {
   IMAGE_DIMENTIONS,
   IResponsiveImageSizes,
   ResponsiveImageTypes,
-} from '../../models/ResponsiveImage';
+} from 'common/models/ResponsiveImage';
+import { getKeys } from 'common/utils/tsHacks';
 
 export type ImageType = ResponsiveImageTypes;
 export type ImageSizes = IResponsiveImageSizes;
@@ -39,7 +38,7 @@ const getSortedDimentionKeys = (type: ImageType) => {
  * @summary Get the most fitting image version to display on screen based on the client screen/pixel size.
  * @param {ResponsiveImageTypes} type
  * @param {number} displayWidth The actual width of the displayed image in real pixel in the screen.
- * @param {ImageSize} currentSize The default/currently displayed size. Resolution should ne be downgraded.
+ * @param {ImageSize} currentSize The default/currently displayed size. Resolution should never be downgraded.
  */
 const getOptimalImageSize = (type: ImageType, displayWidth: number, currentSize: ImageSize): ImageSize => {
   const dimentions = IMAGE_DIMENTIONS[type];

--- a/src/common/components/ResponsiveImage/index.tsx
+++ b/src/common/components/ResponsiveImage/index.tsx
@@ -3,7 +3,7 @@ import React, { FC, ImgHTMLAttributes, useEffect, useState } from 'react';
 import { DOMAIN } from 'common/constants/endpoints';
 import { useBoundingRect } from 'common/hooks/useBoundingRect';
 import IResponsiveImage, {
-  IMAGE_DIMENTIONS,
+  IMAGE_DIMENSIONS,
   IResponsiveImageSizes,
   ResponsiveImageTypes,
 } from 'common/models/ResponsiveImage';
@@ -24,11 +24,11 @@ export interface IProps extends ImgHTMLAttributes<HTMLImageElement> {
  * @example ['xs', 'sm', 'md', 'lg']
  * @param {ImageType} type
  */
-const getSortedDimentionKeys = (type: ImageType) => {
-  return getKeys(IMAGE_DIMENTIONS[type])
+const getSortedDimensionKeys = (type: ImageType) => {
+  return getKeys(IMAGE_DIMENSIONS[type])
     .sort((a, b) => {
-      const [aWidth] = IMAGE_DIMENTIONS[type][a];
-      const [bWidth] = IMAGE_DIMENTIONS[type][b];
+      const [aWidth] = IMAGE_DIMENSIONS[type][a];
+      const [bWidth] = IMAGE_DIMENSIONS[type][b];
       return aWidth - bWidth;
     })
     .filter((t) => t !== 'wide'); // Filter wide because it is unstable, and just mimicks 'lg'.
@@ -41,8 +41,8 @@ const getSortedDimentionKeys = (type: ImageType) => {
  * @param {ImageSize} currentSize The default/currently displayed size. Resolution should never be downgraded.
  */
 const getOptimalImageSize = (type: ImageType, displayWidth: number, currentSize: ImageSize): ImageSize => {
-  const dimentions = IMAGE_DIMENTIONS[type];
-  const keys = getSortedDimentionKeys(type);
+  const dimensions = IMAGE_DIMENSIONS[type];
+  const keys = getSortedDimensionKeys(type);
 
   /** Flag if the compared sizes are larger than the currently displayes size */
   let passedCurrent = false;
@@ -54,8 +54,8 @@ const getOptimalImageSize = (type: ImageType, displayWidth: number, currentSize:
     }
 
     /** Find most fitting image size depending on currently displayed size in DOM */
-    const [currentWidth] = dimentions[keys[i]];
-    const [nextWidth] = dimentions[keys[i + 1]];
+    const [currentWidth] = dimensions[keys[i]];
+    const [nextWidth] = dimensions[keys[i + 1]];
     if (passedCurrent && displayWidth > currentWidth && displayWidth <= nextWidth) {
       return keys[i];
     }

--- a/src/common/components/ResponsiveImage/index.tsx
+++ b/src/common/components/ResponsiveImage/index.tsx
@@ -37,14 +37,14 @@ const getSortedDimensionKeys = (type: ImageType) => {
 /**
  * @summary Get the most fitting image version to display on screen based on the client screen/pixel size.
  * @param {ResponsiveImageTypes} type
- * @param {number} displayWidth The actual width of the displayed image in real pixel in the screen.
+ * @param {number} displayWidth The actual width of the displayed image in real pixels on the screen.
  * @param {ImageSize} currentSize The default/currently displayed size. Resolution should never be downgraded.
  */
 const getOptimalImageSize = (type: ImageType, displayWidth: number, currentSize: ImageSize): ImageSize => {
   const dimensions = IMAGE_DIMENSIONS[type];
   const keys = getSortedDimensionKeys(type);
 
-  /** Flag if the compared sizes are larger than the currently displayes size */
+  /** Flag if the compared sizes are larger than the currently displayed size */
   let passedCurrent = false;
 
   for (let i = 0; i < keys.length - 1; i++) {

--- a/src/common/hooks/useBoundingRect.ts
+++ b/src/common/hooks/useBoundingRect.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useBoundingRect = <T extends HTMLElement>() => {
+  const ref = useRef<T>(null);
+  const [boundingRect, setBoundingRect] = useState<ClientRect | DOMRect | null>(null);
+
+  const updateBoundingRect = () => {
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setBoundingRect(rect);
+    }
+  };
+
+  useEffect(() => {
+    updateBoundingRect();
+  }, [ref, ref.current]);
+
+  const handleResize = () => {
+    updateBoundingRect();
+  };
+
+  useEffect(() => {
+    if (ref.current) {
+      window.addEventListener('resize', handleResize);
+    }
+    return () => {
+      if (ref.current) {
+        window.removeEventListener('resize', handleResize);
+      }
+    };
+  }, []);
+
+  return [ref, boundingRect] as [typeof ref, typeof boundingRect];
+};

--- a/src/common/models/ResponsiveImage.ts
+++ b/src/common/models/ResponsiveImage.ts
@@ -19,13 +19,13 @@ export interface IResponsiveImageSizes {
 
 export type ResponsiveImageTypes = 'article' | 'company' | 'event' | 'offline' | 'product';
 
-export type ResponsiveImageDimentions = {
+export type ResponsiveImageDimensions = {
   [Type in ResponsiveImageTypes]: { [Size in keyof IResponsiveImageSizes]: [number, number] }
 };
 
 const DEFAULT_THUMB_SIZE = [200, 112] as [number, number];
 
-export const IMAGE_DIMENTIONS: ResponsiveImageDimentions = {
+export const IMAGE_DIMENSIONS: ResponsiveImageDimensions = {
   article: {
     thumb: DEFAULT_THUMB_SIZE,
     original: [Infinity, Infinity],

--- a/src/common/models/ResponsiveImage.ts
+++ b/src/common/models/ResponsiveImage.ts
@@ -17,6 +17,62 @@ export interface IResponsiveImageSizes {
   xs: string;
 }
 
+export type ResponsiveImageTypes = 'article' | 'company' | 'event' | 'offline' | 'product';
+
+export type ResponsiveImageDimentions = {
+  [Type in ResponsiveImageTypes]: { [Size in keyof IResponsiveImageSizes]: [number, number] }
+};
+
+const DEFAULT_THUMB_SIZE = [200, 112] as [number, number];
+
+export const IMAGE_DIMENTIONS: ResponsiveImageDimentions = {
+  article: {
+    thumb: DEFAULT_THUMB_SIZE,
+    original: [Infinity, Infinity],
+    wide: [1280, 474],
+    lg: [1280, 474],
+    md: [720, 405],
+    sm: [864, 486],
+    xs: [640, 360],
+  },
+  company: {
+    thumb: DEFAULT_THUMB_SIZE,
+    original: [Infinity, Infinity],
+    wide: [720, 405],
+    lg: [720, 405],
+    md: [320, 180],
+    sm: [320, 180],
+    xs: [160, 90],
+  },
+  event: {
+    thumb: DEFAULT_THUMB_SIZE,
+    original: [Infinity, Infinity],
+    wide: [1280, 720],
+    lg: [1280, 720],
+    md: [720, 405],
+    sm: [720, 405],
+    xs: [640, 360],
+  },
+  offline: {
+    thumb: DEFAULT_THUMB_SIZE,
+    original: [Infinity, Infinity],
+    wide: [1280, 474],
+    lg: [1280, 474],
+    md: [720, 405],
+    sm: [864, 486],
+    xs: [640, 360],
+  },
+  product: {
+    thumb: DEFAULT_THUMB_SIZE,
+    original: [Infinity, Infinity],
+    wide: [520, 624],
+    lg: [520, 624],
+    md: [520, 624],
+    sm: [390, 468],
+    xs: [260, 312],
+  },
+};
+
 export const DEFAULT_EVENT_IMAGE: IResponsiveImage = {
   id: 95,
   name: 'Generisk arrangementsbilde',

--- a/src/events/components/DetailView/PictureCard.tsx
+++ b/src/events/components/DetailView/PictureCard.tsx
@@ -17,7 +17,7 @@ const PictureCard = ({ image, event_start, event_end, location, company_event, e
 
   return (
     <div className={style.pictureCard}>
-      <EventImage companyEvents={company_event} image={image} size="lg" />
+      <EventImage companyEvents={company_event} image={image} size="md" />
 
       <div className={style.attendance}>
         <CardHeader className={style.detailHeader} color={color}>

--- a/src/events/components/EventImage.tsx
+++ b/src/events/components/EventImage.tsx
@@ -12,7 +12,7 @@ export interface IProps extends ImgHTMLAttributes<HTMLImageElement> {
 const EventImage = ({ image, companyEvents: [companyEvent], ...props }: IProps) => {
   const img = companyEvent ? companyEvent.company.image : image;
   const src = img || DEFAULT_EVENT_IMAGE;
-  return <ResponsiveImage image={src} {...props} />;
+  return <ResponsiveImage image={src} type="event" {...props} />;
 };
 
 export default EventImage;

--- a/src/frontpage/components/Articles/MainArticle.tsx
+++ b/src/frontpage/components/Articles/MainArticle.tsx
@@ -8,7 +8,7 @@ const MainArticle = ({ absolute_url, heading, image, ingress }: IArticle) => {
   return (
     <a href={DOMAIN + absolute_url}>
       <div className={style.articleContainer}>
-        <ResponsiveImage className={style.largeImage} image={image} size="sm" />
+        <ResponsiveImage className={style.largeImage} image={image} size="sm" type="article" />
         <div>
           <h2>{heading}</h2>
           <p>{ingress}</p>

--- a/src/frontpage/components/Articles/SmallArticle.tsx
+++ b/src/frontpage/components/Articles/SmallArticle.tsx
@@ -9,7 +9,7 @@ const SmallArticle = ({ absolute_url, heading, image, ingress_short }: IArticle)
   return (
     <a href={DOMAIN + absolute_url}>
       <div className={classnames(style.articleContainer, style.smallArticle)}>
-        <ResponsiveImage image={image} size="xs" className={style.smallImage} />
+        <ResponsiveImage image={image} size="xs" className={style.smallImage} type="article" />
         <div>
           <h2>{heading}</h2>
           <p>{ingress_short}</p>


### PR DESCRIPTION
We have a lot of options for the images we display, but it gets kinda arbitrary which image is actually displayed since people have different screens width different pixel ratios.

This tries to solve the problem of choosing an image size by calculating the optimal image to display based on the current real pixel size of the image in the DOM.