### PR TITLE
Add basic toast message support

### DIFF
--- a/src/common/hooks/useCountDown.ts
+++ b/src/common/hooks/useCountDown.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 
 import { useDecrement } from './useDecrement';
 
-const DEFULAT_TICK = 1000;
+const DEFAULT_TICK = 1000;
 
 const calculateOffset = (time: DateTime, tick: number): number => {
   const endTime = time.toMillis();
@@ -17,7 +17,7 @@ const calculateOffset = (time: DateTime, tick: number): number => {
  * @param tick How often the timer should update. Defaults to every second.
  * @returns Seconds remaining until the countdown is finished.
  */
-export const useCountDown = (endTime: DateTime, tick = DEFULAT_TICK): number => {
+export const useCountDown = (endTime: DateTime, tick = DEFAULT_TICK): number => {
   const duration = calculateOffset(endTime, tick);
   const [remaining, decrement] = useDecrement(duration);
   useEffect(() => {

--- a/src/common/hooks/useCountDown.ts
+++ b/src/common/hooks/useCountDown.ts
@@ -3,22 +3,25 @@ import { useEffect } from 'react';
 
 import { useDecrement } from './useDecrement';
 
-const calculateOffset = (time: DateTime): number => {
+const DEFULAT_TICK = 1000;
+
+const calculateOffset = (time: DateTime, tick: number): number => {
   const endTime = time.toMillis();
   const now = DateTime.local().toMillis();
-  return (endTime - now) / 1000;
+  return (endTime - now) / tick;
 };
 
 /**
  * Hook for counting down toward a specific DateTime.
  * @param endTime
- * @returns {number} Seconds remaining until the countdown is finished.
+ * @param tick How often the timer should update. Defaults to every second.
+ * @returns Seconds remaining until the countdown is finished.
  */
-export const useCountDown = (endTime: DateTime): number => {
-  const duration = calculateOffset(endTime);
+export const useCountDown = (endTime: DateTime, tick = DEFULAT_TICK): number => {
+  const duration = calculateOffset(endTime, tick);
   const [remaining, decrement] = useDecrement(duration);
   useEffect(() => {
-    const interval = setInterval(decrement, 1000);
+    const interval = setInterval(decrement, tick);
     const clear = () => clearInterval(interval);
     return clear;
   }, [remaining]);

--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -2,12 +2,14 @@ import React, { FC } from 'react';
 import Footer from './components/Footer/index';
 import Header from './components/Header/index';
 import './less/core.less';
+import { ToastMessages } from './utils/toast/ToastMessages';
 
 const Core: FC = ({ children }) => (
   <>
     <Header />
     <main>{children}</main>
     <Footer />
+    <ToastMessages />
   </>
 );
 

--- a/src/core/providers/ContextWrapper.tsx
+++ b/src/core/providers/ContextWrapper.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 
 import FrontpageArticles from 'articles/providers/FrontpageArticles';
+import { ToastProvider } from 'core/utils/toast/ToastContext';
 import { EventsRepoProvider } from 'events/providers/EventsRepo';
 import { QueryParamsProviderWithRouter } from './QueryParams';
 
@@ -10,9 +11,11 @@ export interface IProps {
 
 const ContextWrapper = ({ children }: IProps) => (
   <QueryParamsProviderWithRouter>
-    <EventsRepoProvider>
-      <FrontpageArticles>{children}</FrontpageArticles>
-    </EventsRepoProvider>
+    <ToastProvider>
+      <EventsRepoProvider>
+        <FrontpageArticles>{children}</FrontpageArticles>
+      </EventsRepoProvider>
+    </ToastProvider>
   </QueryParamsProviderWithRouter>
 );
 

--- a/src/core/utils/toast/ToastContext.tsx
+++ b/src/core/utils/toast/ToastContext.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, FC, useState } from 'react';
+
+import { DEFAULT_MESSAGE, IToastMessage } from './models';
+
+export interface IToastContextState {
+  messages: IToastMessage[];
+  removeMessage: (id: number) => void;
+  addMessage: (message: Partial<IToastMessage>) => () => void;
+}
+
+export const INITIAL_STATE: IToastContextState = {
+  messages: [],
+  addMessage: () => {
+    throw new Error('Add Toast Message has been called before provider init');
+  },
+  removeMessage: () => {
+    throw new Error('Remove Toast Message has been called before provider init');
+  },
+};
+
+export const ToastContext = createContext(INITIAL_STATE);
+
+/** Used to set an unique ID for each ToastMessage */
+let counter = 0;
+
+export const ToastProvider: FC = ({ children }) => {
+  const [messages, setMessages] = useState(INITIAL_STATE.messages);
+
+  /** Removes a ToastMessage from the list if displayed messages if it exists */
+  const removeMessage = (id: number) => {
+    setMessages((allMessages) => {
+      const index = allMessages.findIndex((message) => message.id === id);
+      if (index !== -1) {
+        const newMessages = [...allMessages];
+        newMessages.splice(index, 1);
+        return newMessages;
+      }
+      return allMessages;
+    });
+  };
+
+  /** Adds a new ToastMessage to the list of messages */
+  const addMessage = (newMessage: Partial<IToastMessage>) => {
+    /** Merge defaults with the new message */
+    const message = { ...DEFAULT_MESSAGE, ...newMessage, id: counter } as IToastMessage;
+    counter++;
+    setMessages((allMessages) => [...allMessages, message]);
+
+    const cancelMessage = () => removeMessage(message.id);
+
+    setTimeout(cancelMessage, message.duration);
+    return cancelMessage;
+  };
+
+  const value = { messages, removeMessage, addMessage };
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+};

--- a/src/core/utils/toast/ToastContext.tsx
+++ b/src/core/utils/toast/ToastContext.tsx
@@ -2,10 +2,15 @@ import React, { createContext, FC, useState } from 'react';
 
 import { DEFAULT_MESSAGE, IToastMessage } from './models';
 
+export interface IAddToastReturn {
+  message: IToastMessage;
+  cancelMessage: () => void;
+}
+
 export interface IToastContextState {
   messages: IToastMessage[];
   removeMessage: (id: number) => void;
-  addMessage: (message: Partial<IToastMessage>) => () => void;
+  addMessage: (message: Partial<IToastMessage>) => IAddToastReturn;
 }
 
 export const INITIAL_STATE: IToastContextState = {
@@ -47,7 +52,7 @@ export const ToastProvider: FC = ({ children }) => {
     setMessages((allMessages) => [...allMessages, message]);
 
     const cancelMessage = () => removeMessage(message.id);
-    return cancelMessage;
+    return { message, cancelMessage };
   };
 
   const value = { messages, removeMessage, addMessage };

--- a/src/core/utils/toast/ToastContext.tsx
+++ b/src/core/utils/toast/ToastContext.tsx
@@ -47,8 +47,6 @@ export const ToastProvider: FC = ({ children }) => {
     setMessages((allMessages) => [...allMessages, message]);
 
     const cancelMessage = () => removeMessage(message.id);
-
-    setTimeout(cancelMessage, message.duration);
     return cancelMessage;
   };
 

--- a/src/core/utils/toast/ToastMessages.tsx
+++ b/src/core/utils/toast/ToastMessages.tsx
@@ -1,47 +1,55 @@
 import { DateTime } from 'luxon';
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import cross from 'common/components/ToggleSwitch/cross.svg';
 import { useCountDown } from 'common/hooks/useCountDown';
 
-import { DEFAULT_DURATION, getToastColor, IToastMessage } from './models';
+import { getToastColor, IToastMessage } from './models';
 import style from './toast.less';
 import { useToast } from './useToast';
 
 export const ToastMessages: FC = () => {
   const { messages, removeMessage } = useToast();
-  return (
+  return messages.length > 0 ? (
     <div className={style.toastContainer}>
       {messages.map((message) => (
-        <Message key={message.id} message={message} onRemove={() => removeMessage(message.id)} />
+        <Message key={message.id} message={message} remove={() => removeMessage(message.id)} />
       ))}
     </div>
-  );
+  ) : null;
 };
 
 export interface IMessageProps {
   message: IToastMessage;
-  onRemove: () => void;
+  remove: () => void;
 }
 
-const COUNTDOWN_SECONDS = DEFAULT_DURATION / 1000;
+const COUNTDOWN_TICK = 200;
 
-const Message: FC<IMessageProps> = ({ message, onRemove }) => {
-  const rawCounter = useCountDown(DateTime.local().plus({ milliseconds: message.duration }));
+const Message: FC<IMessageProps> = ({ message, remove }) => {
+  const countDownSeconds = message.duration / COUNTDOWN_TICK;
+  const rawCounter = useCountDown(DateTime.local().plus({ milliseconds: message.duration }), COUNTDOWN_TICK);
   const counter = Math.round(rawCounter);
 
   const color = getToastColor(message.type);
+
+  useEffect(() => {
+    if (counter === 0) {
+      remove();
+    }
+  }, [counter]);
+
   return (
     <div className={style.messageContainer}>
       <div className={style.messageContent}>
         <p style={{ color }}>{message.content}</p>
-        <button className={style.cancelButton} onClick={onRemove}>
+        <button className={style.cancelButton} onClick={remove}>
           <img src={cross} alt="cross" />
         </button>
       </div>
-      <div className={style.countDownProgress}>
-        {[...Array(COUNTDOWN_SECONDS)].map((_, i) =>
-          COUNTDOWN_SECONDS - counter >= i ? <div key={i} style={{ background: '#fff' }} /> : <div key={i} />
+      <div className={style.countDownProgress} style={{ gridTemplateColumns: `repeat(${countDownSeconds}, 1fr)` }}>
+        {[...Array(countDownSeconds)].map((_, i) =>
+          countDownSeconds - counter >= i ? <div key={i} style={{ background: '#fff' }} /> : <div key={i} />
         )}
       </div>
     </div>

--- a/src/core/utils/toast/ToastMessages.tsx
+++ b/src/core/utils/toast/ToastMessages.tsx
@@ -1,0 +1,49 @@
+import { DateTime } from 'luxon';
+import React, { FC } from 'react';
+
+import cross from 'common/components/ToggleSwitch/cross.svg';
+import { useCountDown } from 'common/hooks/useCountDown';
+
+import { DEFAULT_DURATION, getToastColor, IToastMessage } from './models';
+import style from './toast.less';
+import { useToast } from './useToast';
+
+export const ToastMessages: FC = () => {
+  const { messages, removeMessage } = useToast();
+  return (
+    <div className={style.toastContainer}>
+      {messages.map((message) => (
+        <Message key={message.id} message={message} onRemove={() => removeMessage(message.id)} />
+      ))}
+    </div>
+  );
+};
+
+export interface IMessageProps {
+  message: IToastMessage;
+  onRemove: () => void;
+}
+
+const COUNTDOWN_SECONDS = DEFAULT_DURATION / 1000;
+
+const Message: FC<IMessageProps> = ({ message, onRemove }) => {
+  const rawCounter = useCountDown(DateTime.local().plus({ milliseconds: message.duration }));
+  const counter = Math.round(rawCounter);
+
+  const color = getToastColor(message.type);
+  return (
+    <div className={style.messageContainer}>
+      <div className={style.messageContent}>
+        <p style={{ color }}>{message.content}</p>
+        <button className={style.cancelButton} onClick={onRemove}>
+          <img src={cross} alt="cross" />
+        </button>
+      </div>
+      <div className={style.countDownProgress}>
+        {[...Array(COUNTDOWN_SECONDS)].map((_, i) =>
+          COUNTDOWN_SECONDS - counter >= i ? <div key={i} style={{ background: '#fff' }} /> : <div key={i} />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/core/utils/toast/ToastMessages.tsx
+++ b/src/core/utils/toast/ToastMessages.tsx
@@ -4,7 +4,7 @@ import React, { FC, useEffect } from 'react';
 import cross from 'common/components/ToggleSwitch/cross.svg';
 import { useCountDown } from 'common/hooks/useCountDown';
 
-import { getToastColor, IToastMessage } from './models';
+import { IToastMessage } from './models';
 import style from './toast.less';
 import { useToast } from './useToast';
 
@@ -31,8 +31,6 @@ const Message: FC<IMessageProps> = ({ message, remove }) => {
   const rawCounter = useCountDown(DateTime.local().plus({ milliseconds: message.duration }), COUNTDOWN_TICK);
   const counter = Math.round(rawCounter);
 
-  const color = getToastColor(message.type);
-
   useEffect(() => {
     if (counter === 0) {
       remove();
@@ -42,14 +40,14 @@ const Message: FC<IMessageProps> = ({ message, remove }) => {
   return (
     <div className={style.messageContainer}>
       <div className={style.messageContent}>
-        <p style={{ color }}>{message.content}</p>
+        <p>{message.content}</p>
         <button className={style.cancelButton} onClick={remove}>
           <img src={cross} alt="cross" />
         </button>
       </div>
       <div className={style.countDownProgress} style={{ gridTemplateColumns: `repeat(${countDownSeconds}, 1fr)` }}>
         {[...Array(countDownSeconds)].map((_, i) =>
-          countDownSeconds - counter >= i ? <div key={i} style={{ background: '#fff' }} /> : <div key={i} />
+          countDownSeconds - counter >= i ? <div key={i} className={style.progressTick} /> : <div key={i} />
         )}
       </div>
     </div>

--- a/src/core/utils/toast/models.ts
+++ b/src/core/utils/toast/models.ts
@@ -1,0 +1,31 @@
+export type ToastType = 'info' | 'success' | 'warning' | 'error';
+
+export interface IToastMessage {
+  id: number;
+  content: string;
+  /** milliseconds */
+  duration: number;
+  type: ToastType;
+}
+
+export const DEFAULT_DURATION = 6 * 1000;
+export const DEFAULT_TYPE: ToastType = 'info';
+
+export const DEFAULT_MESSAGE: Partial<IToastMessage> = {
+  duration: DEFAULT_DURATION,
+  type: DEFAULT_TYPE,
+};
+
+export const getToastColor = (type: ToastType) => {
+  switch (type) {
+    /** Use event colors for now, since we dont have specific colors for this */
+    case 'error':
+      return '#eb536e';
+    case 'warning':
+      return '#faa21b';
+    case 'success':
+      return '#43b171';
+    case 'info':
+      return '#fff';
+  }
+};

--- a/src/core/utils/toast/toast.less
+++ b/src/core/utils/toast/toast.less
@@ -1,0 +1,54 @@
+@import '~common/less/mixins.less';
+@import '~common/less/constants.less';
+@import '~common/less/colors.less';
+
+.toastContainer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
+  border: 8px solid transparent;
+  display: grid;
+  gap: 0;
+  width: 400px;
+
+  @media screen and (max-width: @owMobileBreakpoint) {
+    width: 100vw;
+  }
+}
+
+.countDownProgress {
+  display: grid;
+  gap: 0.5px;
+  grid-template-columns: repeat(6, 1fr);
+  margin: 2px;
+
+  > div {
+    height: 1px;
+    width: 100%;
+  }
+}
+
+.messageContainer {
+  box-sizing: border-box;
+  width: 100%;
+  background: #000;
+}
+
+.messageContent {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px;
+  color: #fff;
+  box-sizing: border-box;
+}
+
+.cancelButton {
+  color: #fff;
+  background: unset;
+
+  > img {
+    width: 14px;
+  }
+}

--- a/src/core/utils/toast/toast.less
+++ b/src/core/utils/toast/toast.less
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   border: 8px solid transparent;
   display: grid;
-  gap: 0;
+  gap: 4px;
   width: 400px;
 
   @media screen and (max-width: @owMobileBreakpoint) {
@@ -21,18 +21,23 @@
   display: grid;
   gap: 0.5px;
   grid-template-columns: repeat(6, 1fr);
-  margin: 2px;
+  margin: 0 3px 3px;
 
   > div {
-    height: 1px;
+    height: 2px;
     width: 100%;
   }
 }
 
+.progressTick {
+  background: #fff;
+}
+
 .messageContainer {
+  .owCard();
   box-sizing: border-box;
   width: 100%;
-  background: #000;
+  background: @darkGray;
 }
 
 .messageContent {
@@ -42,6 +47,8 @@
   padding: 8px;
   color: #fff;
   box-sizing: border-box;
+  font-size: @owFontS;
+  font-weight: 600;
 }
 
 .cancelButton {

--- a/src/core/utils/toast/useToast.ts
+++ b/src/core/utils/toast/useToast.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { IToastContextState, ToastContext } from './ToastContext';
+
+export const useToast = (): IToastContextState => {
+  return useContext(ToastContext);
+};

--- a/src/core/utils/toast/useToast.ts
+++ b/src/core/utils/toast/useToast.ts
@@ -1,7 +1,54 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 
+import { IToastMessage, ToastType } from './models';
 import { IToastContextState, ToastContext } from './ToastContext';
 
-export const useToast = (): IToastContextState => {
-  return useContext(ToastContext);
+/**
+ * Settings are used for a single instance of the useToast hook.
+ * To use multiple settings, use multiple instances of the hook in a single component.
+ */
+export interface IToastSettings {
+  /** Removes the previous message from this hook instance before inserting a new message */
+  overwrite?: boolean;
+  /** Declare a type used by all the messages created by this instance of the hook */
+  type?: ToastType;
+  /** Declare a duration used by all the messages created by this instance of the hook */
+  duration?: number;
+}
+
+export const DEFAULT_SETTINGS: IToastSettings = {
+  overwrite: false,
+};
+
+/**
+ * A hook for interfacing with toast messages.
+ * Extends the interfaces in the ToastContext by allowing control of the current/previous message.
+ */
+export const useToast = (settings = DEFAULT_SETTINGS): IToastContextState => {
+  const { addMessage: baseAddMessage, removeMessage, ...rest } = useContext(ToastContext);
+  const [currentMessage, setCurrentMessage] = useState<IToastMessage | null>(null);
+
+  /**
+   * Extend the addMessage function of ToastContext by storing the message.
+   * Applies settings for the instance of the hook that are not global to the entire context.
+   */
+  const addMessage: typeof baseAddMessage = (newMessage) => {
+    if (settings.overwrite && currentMessage) {
+      removeMessage(currentMessage.id);
+    }
+    /** Set the default values only if they are defined in settings and not defined on the message */
+    if (settings.duration !== undefined && newMessage.duration === undefined) {
+      newMessage.duration = settings.duration;
+    }
+    /** Set the default values only if they are defined in settings and not defined on the message */
+    if (settings.type !== undefined && newMessage.duration === undefined) {
+      newMessage.type = settings.type;
+    }
+
+    const { message, cancelMessage } = baseAddMessage(newMessage);
+    setCurrentMessage(message);
+    return { message, cancelMessage };
+  };
+
+  return { addMessage, removeMessage, ...rest };
 };

--- a/src/profile/components/Settings/Privacy/index.tsx
+++ b/src/profile/components/Settings/Privacy/index.tsx
@@ -1,15 +1,18 @@
-import { IUserContext, UserContext } from 'authentication/providers/UserProvider';
+import React, { FC, useContext, useEffect, useState } from 'react';
+
+import { UserContext } from 'authentication/providers/UserProvider';
 import { Pane } from 'common/components/Panes';
 import { getKeys } from 'common/utils/tsHacks';
-import React, { Component } from 'react';
-import { getPrivacyOptions, putPrivacyOptions } from '../../../api/privacy';
-import { IPrivacy } from '../../../models/Privacy';
+import { useToast } from 'core/utils/toast/useToast';
+import { getPrivacyOptions, putPrivacyOptions } from 'profile/api/privacy';
+import { IPrivacy } from 'profile/models/Privacy';
+
 import Info from './Info';
 import Option from './Option';
 
-export type IState = { [key in keyof IPrivacy]: boolean };
+export type PrivacyOptions = { [key in keyof IPrivacy]: boolean };
 
-const INITIAL_STATE: IState = {
+const INITIAL_STATE: PrivacyOptions = {
   expose_address: false,
   expose_email: false,
   expose_nickname: false,
@@ -18,47 +21,60 @@ const INITIAL_STATE: IState = {
   visible_as_attending_events: false,
 };
 
-class Privacy extends Component<{}, IState> {
-  public static contextType = UserContext;
-  public state: IState = INITIAL_STATE;
+const Privacy: FC = () => {
+  const { user } = useContext(UserContext);
+  const [options, setOptions] = useState<PrivacyOptions>(INITIAL_STATE);
 
-  /**
-   * @summary Fetch Privacy options from server and put into state.
-   */
-  public async componentDidMount() {
-    const { user }: IUserContext = this.context;
+  const { addMessage: addSuccessMessage } = useToast({ overwrite: true, type: 'success', duration: 3000 });
+  const { addMessage: addErrorMessage } = useToast({ overwrite: true, type: 'error', duration: 3000 });
+
+  /** Fetch Privacy options from server and put into state. */
+  const fetchInitial = async () => {
     if (user) {
-      const options = await getPrivacyOptions(user);
-      this.setState({ ...options });
+      const serverOptions = await getPrivacyOptions(user);
+      setOptions({ ...serverOptions });
     }
-  }
+  };
+
+  /** Saves/sends current options to server and updates state from server. */
+  const savePrivacyOptions = async (newOptions: PrivacyOptions) => {
+    if (user) {
+      const serverOptions = await putPrivacyOptions(newOptions, user);
+      if (serverOptions) {
+        setOptions(serverOptions);
+        addSuccessMessage({ content: 'Innstillingen ble oppdatert.' });
+      } else {
+        addErrorMessage({ content: 'Det skjedde noe galt under uppdateringen av innstillingen.' });
+      }
+    }
+  };
 
   /**
-   * @summary Toggles an option in state, sends it to server and updates state from server.
+   * @summary Toggles an option in state.
    * @param {keyof IPrivacy} key Key of the option to toggle.
    */
-  public togglePrivacyOption(key: keyof IPrivacy) {
-    const { user }: IUserContext = this.context;
+  const togglePrivacyOption = async (key: keyof IPrivacy) => {
     if (user) {
-      const option = this.state[key];
-      this.setState({ ...this.state, [key]: !option }, async () => {
-        const options = await putPrivacyOptions(this.state, user);
-        this.setState(options);
-      });
+      const option = options[key];
+      const newOptions: PrivacyOptions = { ...options, [key]: !option };
+      setOptions(newOptions);
+      savePrivacyOptions(newOptions);
     }
-  }
+  };
 
-  public render() {
-    const { state } = this;
-    return (
-      <Pane>
-        <Info />
-        {getKeys<IPrivacy>(state).map((key) => (
-          <Option key={key} option={key} value={state[key]} toggle={() => this.togglePrivacyOption(key)} />
-        ))}
-      </Pane>
-    );
-  }
-}
+  /** Fetch initial options on component mount */
+  useEffect(() => {
+    fetchInitial();
+  }, []);
+
+  return (
+    <Pane>
+      <Info />
+      {getKeys<IPrivacy>(options).map((key) => (
+        <Option key={key} option={key} value={options[key]} toggle={() => togglePrivacyOption(key)} />
+      ))}
+    </Pane>
+  );
+};
 
 export default Privacy;


### PR DESCRIPTION
Adds toast messages to with a few usable settings to make it easy to display messages to the user when something is happening.

resolves #258 

_Disclaimer: The stylish button on the top are not included in this PR_
![new-toast](https://user-images.githubusercontent.com/14319313/58374932-43993e00-7f48-11e9-8635-4cc8dc63cd40.gif)
