### PR TITLE
Make toast messages more intuitive

### DIFF
--- a/src/core/utils/toast/ToastContext.tsx
+++ b/src/core/utils/toast/ToastContext.tsx
@@ -1,24 +1,24 @@
 import React, { createContext, FC, useState } from 'react';
 
-import { DEFAULT_MESSAGE, IToastMessage } from './models';
+import { DEFAULT_SETTINGS, IToastMessage, IToastSettings } from './models';
 
 export interface IAddToastReturn {
   message: IToastMessage;
-  cancelMessage: () => void;
+  cancelToast: () => void;
 }
 
 export interface IToastContextState {
   messages: IToastMessage[];
-  removeMessage: (id: number) => void;
-  addMessage: (message: Partial<IToastMessage>) => IAddToastReturn;
+  removeToast: (id: number) => void;
+  createToast: (content: string, settings: IToastSettings) => IAddToastReturn;
 }
 
 export const INITIAL_STATE: IToastContextState = {
   messages: [],
-  addMessage: () => {
+  createToast: () => {
     throw new Error('Add Toast Message has been called before provider init');
   },
-  removeMessage: () => {
+  removeToast: () => {
     throw new Error('Remove Toast Message has been called before provider init');
   },
 };
@@ -32,7 +32,7 @@ export const ToastProvider: FC = ({ children }) => {
   const [messages, setMessages] = useState(INITIAL_STATE.messages);
 
   /** Removes a ToastMessage from the list if displayed messages if it exists */
-  const removeMessage = (id: number) => {
+  const removeToast = (id: number) => {
     setMessages((allMessages) => {
       const index = allMessages.findIndex((message) => message.id === id);
       if (index !== -1) {
@@ -45,16 +45,22 @@ export const ToastProvider: FC = ({ children }) => {
   };
 
   /** Adds a new ToastMessage to the list of messages */
-  const addMessage = (newMessage: Partial<IToastMessage>) => {
+  const createToast = (content: string, settings: IToastSettings) => {
+    const { duration = DEFAULT_SETTINGS.duration, type = DEFAULT_SETTINGS.type } = settings;
     /** Merge defaults with the new message */
-    const message = { ...DEFAULT_MESSAGE, ...newMessage, id: counter } as IToastMessage;
+    const message: IToastMessage = {
+      id: counter,
+      content,
+      duration,
+      type,
+    };
     counter++;
     setMessages((allMessages) => [...allMessages, message]);
 
-    const cancelMessage = () => removeMessage(message.id);
-    return { message, cancelMessage };
+    const cancelToast = () => removeToast(message.id);
+    return { message, cancelToast };
   };
 
-  const value = { messages, removeMessage, addMessage };
+  const value = { messages, removeToast, createToast };
   return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
 };

--- a/src/core/utils/toast/ToastMessages.tsx
+++ b/src/core/utils/toast/ToastMessages.tsx
@@ -1,19 +1,19 @@
 import { DateTime } from 'luxon';
-import React, { FC, useEffect } from 'react';
+import React, { FC, useContext, useEffect } from 'react';
 
 import cross from 'common/components/ToggleSwitch/cross.svg';
 import { useCountDown } from 'common/hooks/useCountDown';
 
 import { IToastMessage } from './models';
 import style from './toast.less';
-import { useToast } from './useToast';
+import { ToastContext } from './ToastContext';
 
 export const ToastMessages: FC = () => {
-  const { messages, removeMessage } = useToast();
+  const { messages, removeToast } = useContext(ToastContext);
   return messages.length > 0 ? (
     <div className={style.toastContainer}>
       {messages.map((message) => (
-        <Message key={message.id} message={message} remove={() => removeMessage(message.id)} />
+        <Message key={message.id} message={message} remove={() => removeToast(message.id)} />
       ))}
     </div>
   ) : null;

--- a/src/core/utils/toast/models.ts
+++ b/src/core/utils/toast/models.ts
@@ -16,6 +16,18 @@ export const DEFAULT_MESSAGE: Partial<IToastMessage> = {
   type: DEFAULT_TYPE,
 };
 
+export interface IToastSettings {
+  overwrite: boolean;
+  type: ToastType;
+  duration: number;
+}
+
+export const DEFAULT_SETTINGS: IToastSettings = {
+  overwrite: false,
+  type: 'info',
+  duration: 6000,
+};
+
 export const getToastColor = (type: ToastType) => {
   switch (type) {
     /** Use event colors for now, since we dont have specific colors for this */

--- a/src/core/utils/toast/toast.less
+++ b/src/core/utils/toast/toast.less
@@ -49,6 +49,7 @@
   box-sizing: border-box;
   font-size: @owFontS;
   font-weight: 600;
+  word-break: break-word;
 }
 
 .cancelButton {
@@ -58,4 +59,20 @@
   > img {
     width: 14px;
   }
+}
+
+.error {
+  background: @red;
+}
+
+.success {
+  background: @green;
+}
+
+.info {
+  background: @darkGray;
+}
+
+.warning {
+  background: @orange;
 }

--- a/src/core/utils/toast/useToast.ts
+++ b/src/core/utils/toast/useToast.ts
@@ -1,54 +1,54 @@
 import { useContext, useState } from 'react';
 
-import { IToastMessage, ToastType } from './models';
-import { IToastContextState, ToastContext } from './ToastContext';
+import { DEFAULT_SETTINGS, IToastMessage, IToastSettings } from './models';
+import { ToastContext } from './ToastContext';
 
 /**
  * Settings are used for a single instance of the useToast hook.
  * To use multiple settings, use multiple instances of the hook in a single component.
  */
-export interface IToastSettings {
-  /** Removes the previous message from this hook instance before inserting a new message */
-  overwrite?: boolean;
-  /** Declare a type used by all the messages created by this instance of the hook */
-  type?: ToastType;
-  /** Declare a duration used by all the messages created by this instance of the hook */
-  duration?: number;
-}
 
-export const DEFAULT_SETTINGS: IToastSettings = {
-  overwrite: false,
-};
+export type AddToast = (content: string, messageSettings?: Partial<IToastSettings>) => [IToastMessage, () => void];
+export type CancelToast = () => void;
 
 /**
  * A hook for interfacing with toast messages.
  * Extends the interfaces in the ToastContext by allowing control of the current/previous message.
  */
-export const useToast = (settings = DEFAULT_SETTINGS): IToastContextState => {
-  const { addMessage: baseAddMessage, removeMessage, ...rest } = useContext(ToastContext);
-  const [currentMessage, setCurrentMessage] = useState<IToastMessage | null>(null);
+export const useToast = (hookSettings: Partial<IToastSettings> = {}): [AddToast, CancelToast] => {
+  const { createToast, removeToast } = useContext(ToastContext);
+  const [currentToast, setCurrentToast] = useState<IToastMessage | null>(null);
 
-  /**
-   * Extend the addMessage function of ToastContext by storing the message.
-   * Applies settings for the instance of the hook that are not global to the entire context.
-   */
-  const addMessage: typeof baseAddMessage = (newMessage) => {
-    if (settings.overwrite && currentMessage) {
-      removeMessage(currentMessage.id);
-    }
-    /** Set the default values only if they are defined in settings and not defined on the message */
-    if (settings.duration !== undefined && newMessage.duration === undefined) {
-      newMessage.duration = settings.duration;
-    }
-    /** Set the default values only if they are defined in settings and not defined on the message */
-    if (settings.type !== undefined && newMessage.duration === undefined) {
-      newMessage.type = settings.type;
-    }
-
-    const { message, cancelMessage } = baseAddMessage(newMessage);
-    setCurrentMessage(message);
-    return { message, cancelMessage };
+  const cancelCurrentToast: CancelToast = () => {
+    setCurrentToast((current) => {
+      if (current) {
+        removeToast(current.id);
+        return null;
+      }
+      return currentToast;
+    });
   };
 
-  return { addMessage, removeMessage, ...rest };
+  /**
+   * Extend the createToast function of ToastContext by storing the toast and applying settings.
+   * Applies settings for the instance of the hook that are not global to the entire context.
+   */
+  const addToast: AddToast = (content, messageSettings = {}) => {
+    /** Merge the defualt settings, hook level settings and message level settings */
+    const settings: IToastSettings = {
+      ...DEFAULT_SETTINGS,
+      ...hookSettings,
+      ...messageSettings,
+    };
+
+    if (settings.overwrite) {
+      cancelCurrentToast();
+    }
+
+    const { message, cancelToast } = createToast(content, settings);
+    setCurrentToast(message);
+    return [message, cancelToast];
+  };
+
+  return [addToast, cancelCurrentToast];
 };

--- a/src/profile/components/Settings/Privacy/index.tsx
+++ b/src/profile/components/Settings/Privacy/index.tsx
@@ -25,8 +25,8 @@ const Privacy: FC = () => {
   const { user } = useContext(UserContext);
   const [options, setOptions] = useState<PrivacyOptions>(INITIAL_STATE);
 
-  const { addMessage: addSuccessMessage } = useToast({ overwrite: true, type: 'success', duration: 3000 });
-  const { addMessage: addErrorMessage } = useToast({ overwrite: true, type: 'error', duration: 3000 });
+  const [displaySuccess] = useToast({ overwrite: true, type: 'success', duration: 3000 });
+  const [displayError] = useToast({ overwrite: true, type: 'error', duration: 3000 });
 
   /** Fetch Privacy options from server and put into state. */
   const fetchInitial = async () => {
@@ -42,9 +42,9 @@ const Privacy: FC = () => {
       const serverOptions = await putPrivacyOptions(newOptions, user);
       if (serverOptions) {
         setOptions(serverOptions);
-        addSuccessMessage({ content: 'Innstillingen ble oppdatert.' });
+        displaySuccess('Innstillingen ble oppdatert.');
       } else {
-        addErrorMessage({ content: 'Det skjedde noe galt under uppdateringen av innstillingen.' });
+        displayError('Det skjedde noe galt under uppdateringen av innstillingen.');
       }
     }
   };


### PR DESCRIPTION
After using the toast api for a bit, I understood that it was needlessly cumbersome to use.

Also added `word-break` to make sure messages width is correct.

This makes toast messages use a common settings pattern wherever they are invoked.
There are 3 levels of settings:
- Default settings: A complete set of settings that are set as default.
- Hook settings: Settings added when the hook is invoked in the function body. These settings will be used by all the toasts created that hook.
- Message settings: Settings used only for that exact message.

The settings are applied in that order, and any setting applied in a later level will overwrite settings from previous levels.

### Examples:

#### Using default settings:

``` typescript
const Foo: FC = () => {
  const [displayMessage] = useToast();
  
  useEffect(() => {
    displayMessage('Component Foo has mounted!');
  }, []);

  return (...);
};
```

#### Adding hook level settings:

``` typescript
const Foo: FC = () => {
  const [displayMessage] = useToast({ overwrite: true });
  
  const handleClick = () => {
    displayMessage('This message will remove/overwrite the previous message before displaying!');
  }, []);

  return (
    <button onClick={handleClick}>
      Click me to display a message
    </button>
  );
};
```

#### Adding message level settings

``` typescript
const Foo: FC = () => {
  /** Messages will display on screen for 6 seconds */
  const [displayMessage] = useToast({ duration: 6 * 1000 });
  
  const handleClick = () => {
    displayMessage('This message will only display for 3 seconds', { duration: 3 * 1000 });
  }, []);

  return (
    <button onClick={handleClick}>
      Click me to display a message
    </button>
  );
};
```