### PR TITLE
Add support for saldo payments with Stripe

### DIFF
--- a/config/environment.config.js
+++ b/config/environment.config.js
@@ -12,6 +12,10 @@ const BASE_CONFIG = {
   OWF_SSR: 'false',
   OWF_VAPID_PUBLIC_KEY: '',
   OWF_WEBPUSH_SERVER_URL: '',
+  STRIPE_PUBLIC_KEY_ARRKOM: null,
+  STRIPE_PUBLIC_KEY_FAGKOM: null,
+  STRIPE_PUBLIC_KEY_PROKOM: null,
+  STRIPE_PUBLIC_KEY_TRIKOM: null,
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "dependencies": {
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
+    "@fortawesome/free-brands-svg-icons": "^5.8.2",
     "@fortawesome/free-regular-svg-icons": "^5.7.2",
     "@fortawesome/free-solid-svg-icons": "^5.7.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
@@ -115,6 +116,7 @@
     "@types/classnames": "^2.2.7",
     "@types/express-http-proxy": "^1.5.0",
     "@types/react-select": "^2.0.17",
+    "@types/react-stripe-elements": "^1.1.10",
     "abortcontroller-polyfill": "^1.2.3",
     "assets-webpack-plugin": "^3.9.7",
     "babel-core": "7.0.0-bridge.0",
@@ -127,7 +129,8 @@
     "react-day-picker": "^7.3.0",
     "react-ga": "^2.5.7",
     "react-loadable": "^5.5.0",
-    "react-select": "^2.4.2"
+    "react-select": "^2.4.2",
+    "react-stripe-elements": "^3.0.0"
   },
   "resolutions": {
     "@types/react": "^16.8.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import HttpError from './core/components/errors/HttpError';
 import { Route } from './core/components/Router';
 import Frontpage from './frontpage';
 import Hobbys from './hobbygroups';
+import { Payments } from './payments';
 import Resources from './resources';
 
 /** Luxon locale setting has to be the same as in the front-end */
@@ -28,6 +29,7 @@ export const routes = {
   wiki: '/wiki',
   webshop: '/webshop',
   profile: '/profile',
+  payments: '/payments',
   authCallback: '/auth/callback',
   spinner: '/spinner',
 };
@@ -57,6 +59,7 @@ export const Client = () => (
       <Route path={routes.profile} component={LoadableProfile} requireLogin />
       <Route path={routes.authCallback} component={AuthCallback} />
       <Route path={routes.spinner} component={Spinner} />
+      <Route path={routes.payments} component={Payments} requireLogin />
       <Route path="*" render={() => <HttpError code={404} />} />
     </Switch>
   </Core>

--- a/src/common/components/Table/index.tsx
+++ b/src/common/components/Table/index.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+
+import style from './table.less';
+
+export interface IProps {
+  headers: string[];
+  title?: string;
+}
+
+export const Table: FC<IProps> = ({ headers, title, children }) => {
+  return (
+    <div className={style.container}>
+      <table>
+        {title ? <caption>{title}</caption> : null}
+        <thead>
+          <tr>
+            {headers.map((header) => (
+              <th key={header} scope="col">
+                <h3 className={style.header}>{header}</h3>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/common/components/Table/table.less
+++ b/src/common/components/Table/table.less
@@ -1,0 +1,56 @@
+@import '~common/less/colors.less';
+@import '~common/less/mixins.less';
+@import '~common/less/constants.less';
+
+.container {
+  .owCard();
+  padding: 16px;
+  width: 100%;
+  box-sizing: border-box;
+
+  > table {
+    table-layout: fixed;
+    width: 100%;
+    border-collapse: collapse;
+
+    > caption {
+      font-size: @owFontL;
+      margin: 10px;
+    }
+
+    > thead {
+      border-bottom: 0.5px solid #333;
+    }
+
+    > tbody {
+      th,
+      td {
+        padding: 10px 0;
+        width: 100%;
+      }
+      tr {
+        height: 100%;
+        margin: 10px;
+        min-height: 50px;
+
+        &:nth-child(even) {
+          background-color: #f9f9f9;
+        }
+
+        &:nth-child(odd) {
+          background-color: #fff;
+        }
+      }
+    }
+  }
+}
+
+.header {
+  padding: 16px 0;
+  word-break: break-word;
+  hyphens: auto;
+
+  @media screen and (max-width: @owMobileBreakpoint) {
+    font-size: @owFontS;
+  }
+}

--- a/src/common/components/Verification/Check.tsx
+++ b/src/common/components/Verification/Check.tsx
@@ -1,14 +1,11 @@
-import React from 'react';
+import React, { FC } from 'react';
 
-export interface IProps {
-  color?: string;
-  checkColor?: string;
-}
+import { IIconProps } from './GenericIcon';
 
-const Check = ({ color = '#27AE60', checkColor = 'white' }: IProps) => (
+const Check: FC<IIconProps> = ({ color = '#27AE60', iconColor = 'white' }) => (
   <svg width="100%" height="100%" viewBox="0 0 27 27" fill="none">
     <circle cx="13.5" cy="13.5" r="13.5" fill={color} />
-    <path d="M7.5 12.4657L6 13.9657L11 18.9657L20.5419 9.42362L19.1183 8L11 15.9657L7.5 12.4657Z" fill={checkColor} />
+    <path d="M7.5 12.4657L6 13.9657L11 18.9657L20.5419 9.42362L19.1183 8L11 15.9657L7.5 12.4657Z" fill={iconColor} />
   </svg>
 );
 

--- a/src/common/components/Verification/Circle.tsx
+++ b/src/common/components/Verification/Circle.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react';
+
+import { IIconProps } from './GenericIcon';
+
+const Circle: FC<IIconProps> = ({ color = '#2AC6F9', iconColor = 'white' }) => (
+  <svg width="100%" height="100%" viewBox="0 0 27 27" fill="none">
+    <circle cx="13.5" cy="13.5" r="13.5" fill={color} />
+    <circle cx="13.5" cy="13.5" r="7.2" stroke={iconColor} strokeWidth="1.6" />
+  </svg>
+);
+
+export default Circle;

--- a/src/common/components/Verification/Cross.tsx
+++ b/src/common/components/Verification/Cross.tsx
@@ -1,15 +1,12 @@
-import React from 'react';
+import React, { FC } from 'react';
 
-export interface IProps {
-  color?: string;
-  crossColor?: string;
-}
+import { IIconProps } from './GenericIcon';
 
-const Cross = ({ color = '#EB5757', crossColor = 'white' }: IProps) => (
+const Cross: FC<IIconProps> = ({ color = '#EB5757', iconColor = 'white' }) => (
   <svg width="100%" height="100%" viewBox="0 0 27 27" fill="none">
     <circle cx="13.5" cy="13.5" r="13.5" fill={color} />
-    <path d="M7.41895 8.55029L8.55032 7.41892L19.5812 18.4498L18.4498 19.5812L7.41895 8.55029Z" fill={crossColor} />
-    <path d="M8.55029 19.5811L7.41892 18.4497L18.4498 7.41882L19.5812 8.55019L8.55029 19.5811Z" fill={crossColor} />
+    <path d="M7.41895 8.55029L8.55032 7.41892L19.5812 18.4498L18.4498 19.5812L7.41895 8.55029Z" fill={iconColor} />
+    <path d="M8.55029 19.5811L7.41892 18.4497L18.4498 7.41882L19.5812 8.55019L8.55029 19.5811Z" fill={iconColor} />
   </svg>
 );
 

--- a/src/common/components/Verification/GenericIcon.tsx
+++ b/src/common/components/Verification/GenericIcon.tsx
@@ -1,0 +1,4 @@
+export interface IIconProps {
+  color?: string;
+  iconColor?: string;
+}

--- a/src/common/components/Verification/Pause.tsx
+++ b/src/common/components/Verification/Pause.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from 'react';
+
+import { IIconProps } from './GenericIcon';
+
+const Pause: FC<IIconProps> = ({ color = '#C4C4c4', iconColor = 'white' }) => (
+  <svg width="100%" height="100%" viewBox="0 0 27 27" fill="none">
+    <circle cx="13.5" cy="13.5" r="13.5" fill={color} />
+    <rect x="15.5" y="8" width="3" height="11" fill={iconColor} />
+    <rect x="8.5" y="8" width="3" height="11" fill={iconColor} />
+  </svg>
+);
+
+export default Pause;

--- a/src/common/components/Verification/Square.tsx
+++ b/src/common/components/Verification/Square.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react';
+
+import { IIconProps } from './GenericIcon';
+
+const Square: FC<IIconProps> = ({ color = '#8A35E0', iconColor = 'white' }) => (
+  <svg width="100%" height="100%" viewBox="0 0 27 27" fill="none">
+    <circle cx="13.5" cy="13.5" r="13.5" fill={color} />
+    <rect x="7.3" y="7.3" width="12.4" height="12.4" stroke={iconColor} strokeWidth="1.6" />
+  </svg>
+);
+
+export default Square;

--- a/src/common/constants/stripe.ts
+++ b/src/common/constants/stripe.ts
@@ -1,0 +1,10 @@
+/**
+ * Stripe _PUBLIC_ keys.
+ * Keys are set to a fake key as default, as Stripe requires a key to even render components.
+ * Stripe keys can be found in the development settings on the Stripe Account,
+ * or in the wiki: https://online.ntnu.no/wiki/komiteer/dotkom/aktuelt/onlineweb4/keys/
+ */
+export const STRIPE_KEY_ARRKOM = process.env.STRIPE_PUBLIC_KEY_ARRKOM || 'stripe_123';
+export const STRIPE_KEY_FAGKOM = process.env.STRIPE_PUBLIC_KEY_FAGKOM || 'stripe_123';
+export const STRIPE_KEY_PROKOM = process.env.STRIPE_PUBLIC_KEY_PROKOM || 'stripe_123';
+export const STRIPE_KEY_TRIKOM = process.env.STRIPE_PUBLIC_KEY_TRIKOM || 'stripe_123';

--- a/src/common/less/mixins.less
+++ b/src/common/less/mixins.less
@@ -8,10 +8,14 @@
   }
 }
 
+.owBorderRadius {
+  border-radius: 3px;
+}
+
 .owCard {
   background: #fff;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-  border-radius: 3px;
+  .owBorderRadius();
 }
 
 /* Polyfill for focus-visible adds a class to the focused elements */

--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -115,7 +115,7 @@ export interface IPutParams<T> {
   options?: IRequestOptions;
 }
 
-export const put = async <T>(putParams: IPutParams<Partial<T>>): Promise<T> => {
+export const put = async <T, K = Partial<T>>(putParams: IPutParams<K>): Promise<T> => {
   const { query, data, parameters = {}, options = {} } = putParams;
   const headers = {
     Accept: 'application/json',
@@ -123,5 +123,16 @@ export const put = async <T>(putParams: IPutParams<Partial<T>>): Promise<T> => {
   };
   const body = JSON.stringify(data);
   const opts = { ...options, method: 'PUT', body, headers };
+  return performRequest(query, parameters, opts);
+};
+
+export const patch = async <T, K = Partial<T>>(patchParams: IPutParams<K>): Promise<T> => {
+  const { query, data, parameters = {}, options = {} } = patchParams;
+  const headers = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+  const body = JSON.stringify(data);
+  const opts = { ...options, method: 'PATCH', body, headers };
   return performRequest(query, parameters, opts);
 };

--- a/src/core/utils/toast/ToastContext.tsx
+++ b/src/core/utils/toast/ToastContext.tsx
@@ -1,24 +1,24 @@
 import React, { createContext, FC, useState } from 'react';
 
-import { DEFAULT_MESSAGE, IToastMessage } from './models';
+import { DEFAULT_SETTINGS, IToastMessage, IToastSettings } from './models';
 
 export interface IAddToastReturn {
   message: IToastMessage;
-  cancelMessage: () => void;
+  cancelToast: () => void;
 }
 
 export interface IToastContextState {
   messages: IToastMessage[];
-  removeMessage: (id: number) => void;
-  addMessage: (message: Partial<IToastMessage>) => IAddToastReturn;
+  removeToast: (id: number) => void;
+  createToast: (content: string, settings: IToastSettings) => IAddToastReturn;
 }
 
 export const INITIAL_STATE: IToastContextState = {
   messages: [],
-  addMessage: () => {
+  createToast: () => {
     throw new Error('Add Toast Message has been called before provider init');
   },
-  removeMessage: () => {
+  removeToast: () => {
     throw new Error('Remove Toast Message has been called before provider init');
   },
 };
@@ -32,7 +32,7 @@ export const ToastProvider: FC = ({ children }) => {
   const [messages, setMessages] = useState(INITIAL_STATE.messages);
 
   /** Removes a ToastMessage from the list if displayed messages if it exists */
-  const removeMessage = (id: number) => {
+  const removeToast = (id: number) => {
     setMessages((allMessages) => {
       const index = allMessages.findIndex((message) => message.id === id);
       if (index !== -1) {
@@ -45,16 +45,22 @@ export const ToastProvider: FC = ({ children }) => {
   };
 
   /** Adds a new ToastMessage to the list of messages */
-  const addMessage = (newMessage: Partial<IToastMessage>) => {
+  const createToast = (content: string, settings: IToastSettings) => {
+    const { duration = DEFAULT_SETTINGS.duration, type = DEFAULT_SETTINGS.type } = settings;
     /** Merge defaults with the new message */
-    const message = { ...DEFAULT_MESSAGE, ...newMessage, id: counter } as IToastMessage;
+    const message: IToastMessage = {
+      id: counter,
+      content,
+      duration,
+      type,
+    };
     counter++;
     setMessages((allMessages) => [...allMessages, message]);
 
-    const cancelMessage = () => removeMessage(message.id);
-    return { message, cancelMessage };
+    const cancelToast = () => removeToast(message.id);
+    return { message, cancelToast };
   };
 
-  const value = { messages, removeMessage, addMessage };
+  const value = { messages, removeToast, createToast };
   return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
 };

--- a/src/core/utils/toast/ToastMessages.tsx
+++ b/src/core/utils/toast/ToastMessages.tsx
@@ -1,19 +1,19 @@
 import { DateTime } from 'luxon';
-import React, { FC, useEffect } from 'react';
+import React, { FC, useContext, useEffect } from 'react';
 
 import cross from 'common/components/ToggleSwitch/cross.svg';
 import { useCountDown } from 'common/hooks/useCountDown';
 
 import { IToastMessage } from './models';
 import style from './toast.less';
-import { useToast } from './useToast';
+import { ToastContext } from './ToastContext';
 
 export const ToastMessages: FC = () => {
-  const { messages, removeMessage } = useToast();
+  const { messages, removeToast } = useContext(ToastContext);
   return messages.length > 0 ? (
     <div className={style.toastContainer}>
       {messages.map((message) => (
-        <Message key={message.id} message={message} remove={() => removeMessage(message.id)} />
+        <Message key={message.id} message={message} remove={() => removeToast(message.id)} />
       ))}
     </div>
   ) : null;

--- a/src/core/utils/toast/models.ts
+++ b/src/core/utils/toast/models.ts
@@ -16,6 +16,18 @@ export const DEFAULT_MESSAGE: Partial<IToastMessage> = {
   type: DEFAULT_TYPE,
 };
 
+export interface IToastSettings {
+  overwrite: boolean;
+  type: ToastType;
+  duration: number;
+}
+
+export const DEFAULT_SETTINGS: IToastSettings = {
+  overwrite: false,
+  type: 'info',
+  duration: 6000,
+};
+
 export const getToastColor = (type: ToastType) => {
   switch (type) {
     /** Use event colors for now, since we dont have specific colors for this */

--- a/src/core/utils/toast/toast.less
+++ b/src/core/utils/toast/toast.less
@@ -49,6 +49,7 @@
   box-sizing: border-box;
   font-size: @owFontS;
   font-weight: 600;
+  word-break: break-word;
 }
 
 .cancelButton {
@@ -58,4 +59,20 @@
   > img {
     width: 14px;
   }
+}
+
+.error {
+  background: @red;
+}
+
+.success {
+  background: @green;
+}
+
+.info {
+  background: @darkGray;
+}
+
+.warning {
+  background: @orange;
 }

--- a/src/core/utils/toast/useToast.ts
+++ b/src/core/utils/toast/useToast.ts
@@ -1,54 +1,54 @@
 import { useContext, useState } from 'react';
 
-import { IToastMessage, ToastType } from './models';
-import { IToastContextState, ToastContext } from './ToastContext';
+import { DEFAULT_SETTINGS, IToastMessage, IToastSettings } from './models';
+import { ToastContext } from './ToastContext';
 
 /**
  * Settings are used for a single instance of the useToast hook.
  * To use multiple settings, use multiple instances of the hook in a single component.
  */
-export interface IToastSettings {
-  /** Removes the previous message from this hook instance before inserting a new message */
-  overwrite?: boolean;
-  /** Declare a type used by all the messages created by this instance of the hook */
-  type?: ToastType;
-  /** Declare a duration used by all the messages created by this instance of the hook */
-  duration?: number;
-}
 
-export const DEFAULT_SETTINGS: IToastSettings = {
-  overwrite: false,
-};
+export type AddToast = (content: string, messageSettings?: Partial<IToastSettings>) => [IToastMessage, () => void];
+export type CancelToast = () => void;
 
 /**
  * A hook for interfacing with toast messages.
  * Extends the interfaces in the ToastContext by allowing control of the current/previous message.
  */
-export const useToast = (settings = DEFAULT_SETTINGS): IToastContextState => {
-  const { addMessage: baseAddMessage, removeMessage, ...rest } = useContext(ToastContext);
-  const [currentMessage, setCurrentMessage] = useState<IToastMessage | null>(null);
+export const useToast = (hookSettings: Partial<IToastSettings> = {}): [AddToast, CancelToast] => {
+  const { createToast, removeToast } = useContext(ToastContext);
+  const [currentToast, setCurrentToast] = useState<IToastMessage | null>(null);
 
-  /**
-   * Extend the addMessage function of ToastContext by storing the message.
-   * Applies settings for the instance of the hook that are not global to the entire context.
-   */
-  const addMessage: typeof baseAddMessage = (newMessage) => {
-    if (settings.overwrite && currentMessage) {
-      removeMessage(currentMessage.id);
-    }
-    /** Set the default values only if they are defined in settings and not defined on the message */
-    if (settings.duration !== undefined && newMessage.duration === undefined) {
-      newMessage.duration = settings.duration;
-    }
-    /** Set the default values only if they are defined in settings and not defined on the message */
-    if (settings.type !== undefined && newMessage.duration === undefined) {
-      newMessage.type = settings.type;
-    }
-
-    const { message, cancelMessage } = baseAddMessage(newMessage);
-    setCurrentMessage(message);
-    return { message, cancelMessage };
+  const cancelCurrentToast: CancelToast = () => {
+    setCurrentToast((current) => {
+      if (current) {
+        removeToast(current.id);
+        return null;
+      }
+      return currentToast;
+    });
   };
 
-  return { addMessage, removeMessage, ...rest };
+  /**
+   * Extend the createToast function of ToastContext by storing the toast and applying settings.
+   * Applies settings for the instance of the hook that are not global to the entire context.
+   */
+  const addToast: AddToast = (content, messageSettings = {}) => {
+    /** Merge the defualt settings, hook level settings and message level settings */
+    const settings: IToastSettings = {
+      ...DEFAULT_SETTINGS,
+      ...hookSettings,
+      ...messageSettings,
+    };
+
+    if (settings.overwrite) {
+      cancelCurrentToast();
+    }
+
+    const { message, cancelToast } = createToast(content, settings);
+    setCurrentToast(message);
+    return [message, cancelToast];
+  };
+
+  return [addToast, cancelCurrentToast];
 };

--- a/src/payments/api/paymentTransaction.ts
+++ b/src/payments/api/paymentTransaction.ts
@@ -1,0 +1,148 @@
+import { getUser } from 'authentication/api';
+import { getAllPages, patch, post } from 'common/utils/api';
+import {
+  ICreatePaymentTransaction,
+  IPaymentTransaction,
+  IUpdatePaymentTransaction,
+} from 'payments/models/PaymentTransaction';
+import { ReactStripeElements } from 'react-stripe-elements';
+
+const API_URL = '/api/v1/payment/transactions/';
+
+/**
+ * Get all transactiont the current user has made.
+ * Purchases in Nibble, updates to Saldo, etc.
+ */
+export const getAllTransactions = async () => {
+  const user = await getUser();
+  const data = await getAllPages<IPaymentTransaction>(API_URL, { format: 'json' }, { user });
+  return data;
+};
+
+/**
+ * Create a transaction for adding saldo to the user.
+ * Requres a Stripe Intent.
+ */
+export const postTransaction = async (transaction: ICreatePaymentTransaction) => {
+  const user = await getUser();
+  const data = await post<IPaymentTransaction>(API_URL, transaction, { format: 'json' }, { user });
+  return data;
+};
+
+/**
+ * Verify a Transaction that is pending because Stripe needed more verification (3D Secure/SCA)
+ */
+export const verifyTransaction = async (transactionId: number, transaction: IUpdatePaymentTransaction) => {
+  const user = await getUser();
+  const data = await patch<IPaymentTransaction, IUpdatePaymentTransaction>({
+    query: `${API_URL}${transactionId}/`,
+    data: transaction,
+    parameters: { format: 'json' },
+    options: { user },
+  });
+  return data;
+};
+
+export interface IGenericReturn {
+  status: 'error' | 'success' | 'pending';
+  message: string;
+}
+
+export interface ICreatePaymentMethodReturn extends IGenericReturn {
+  paymentMethod?: IPaymentTransaction;
+}
+
+export const createPaymentMethod = async (
+  stripe: ReactStripeElements.StripeProps
+): Promise<ICreatePaymentMethodReturn> => {
+  const user = await getUser();
+
+  if (!user) {
+    return {
+      status: 'error',
+      message: 'Du er ikke logget inn, og kan derfor ikke betale.',
+    };
+  }
+
+  const data = {
+    billing_details: {
+      name: user.profile.name,
+    },
+  };
+
+  const { paymentMethod, error } = await stripe.createPaymentMethod('card', data);
+
+  if (error) {
+    return {
+      status: 'error',
+      message: 'Kunne ikke fullføre betalingen',
+    };
+  }
+
+  return {
+    status: 'success',
+    message: 'Betalingen er under behandling...',
+    paymentMethod,
+  };
+};
+
+export interface ICreateTransactionReturn extends IGenericReturn {
+  transaction?: IPaymentTransaction;
+}
+
+// tslint:disable-next-line no-any
+export const createTransaction = async (amount: number, paymentMethod: any): Promise<ICreateTransactionReturn> => {
+  const transaction = await postTransaction({ amount, payment_method_id: paymentMethod.id });
+
+  if (transaction.status === 'done') {
+    return {
+      status: 'success',
+      message: `Det ble lagt til ${transaction.amount} kr til saldo for din bruker`,
+    };
+  } else if (transaction.status === 'pending') {
+    return {
+      status: 'pending',
+      message: 'Betalingen trenger videre behandling...',
+      transaction,
+    };
+  } else {
+    return {
+      status: 'error',
+      message: 'Kunne ikke lagre betalingen!',
+    };
+  }
+};
+
+export interface IHandleCardVerificationReturn extends IGenericReturn {
+  transaction?: IPaymentTransaction;
+}
+
+export const handleCardVerification = async (
+  stripe: ReactStripeElements.StripeProps,
+  transaction: IPaymentTransaction
+): Promise<IHandleCardVerificationReturn> => {
+  // @ts-ignore Stripe types are not up to spec.
+  const { paymentIntent, error } = await stripe.handleCardAction(transaction.payment_intent_secret);
+
+  if (error) {
+    return {
+      status: 'error',
+      message: error.message,
+    };
+  }
+
+  const verifiedTransaction = await verifyTransaction(transaction.id, { payment_intent_id: paymentIntent.id });
+
+  if (verifiedTransaction.status === 'done') {
+    return {
+      status: 'success',
+      message: `Det ble lagt til ${transaction.amount} kr til saldo for din bruker`,
+      transaction: verifiedTransaction,
+    };
+  }
+
+  return {
+    status: 'error',
+    message: 'Kunne ikke verifisere betalingen...',
+  };
+};

--- a/src/payments/components/Paid/index.tsx
+++ b/src/payments/components/Paid/index.tsx
@@ -1,0 +1,14 @@
+import React, { FC } from 'react';
+
+import Check from 'common/components/Verification/Check';
+import Cross from 'common/components/Verification/Cross';
+
+import style from './paid.less';
+
+export interface IPaidProps {
+  paid: boolean;
+}
+
+export const Paid: FC<IPaidProps> = ({ paid }) => {
+  return <p className={style.icon}>{paid ? <Check /> : <Cross />}</p>;
+};

--- a/src/payments/components/Paid/paid.less
+++ b/src/payments/components/Paid/paid.less
@@ -1,0 +1,3 @@
+.icon {
+  width: 22px;
+}

--- a/src/payments/components/Status/index.tsx
+++ b/src/payments/components/Status/index.tsx
@@ -1,0 +1,52 @@
+import React, { FC } from 'react';
+
+import Check from 'common/components/Verification/Check';
+import Cross from 'common/components/Verification/Cross';
+import { PaymentStatus } from 'payments/models/Payment';
+
+import style from './status.less';
+
+export const getStatusDisplay = (status: PaymentStatus) => {
+  switch (status) {
+    case 'pending':
+      return 'Uferdig';
+    case 'succeeded':
+      return 'Betalt, ikke lagret';
+    case 'done':
+      return 'Betalt';
+    case 'refunded':
+      return 'Refundert, ikke lagret';
+    case 'removed':
+      return 'Refundert og fjernet';
+  }
+};
+
+export const getStatusIcon = (status: PaymentStatus) => {
+  switch (status) {
+    case 'pending':
+      return Cross;
+    case 'succeeded':
+      return Check;
+    case 'done':
+      return Check;
+    case 'refunded':
+      return Cross;
+    case 'removed':
+      return Cross;
+  }
+};
+
+export interface IProps {
+  status: PaymentStatus;
+}
+
+export const Status: FC<IProps> = ({ status }) => {
+  const text = getStatusDisplay(status);
+  const Icon = getStatusIcon(status);
+
+  return (
+    <p className={style.icon} title={text}>
+      <Icon />
+    </p>
+  );
+};

--- a/src/payments/components/Status/index.tsx
+++ b/src/payments/components/Status/index.tsx
@@ -1,7 +1,10 @@
 import React, { FC } from 'react';
 
 import Check from 'common/components/Verification/Check';
+import Circle from 'common/components/Verification/Circle';
 import Cross from 'common/components/Verification/Cross';
+import Pause from 'common/components/Verification/Pause';
+import Square from 'common/components/Verification/Square';
 import { PaymentStatus } from 'payments/models/Payment';
 
 import style from './status.less';
@@ -24,13 +27,13 @@ export const getStatusDisplay = (status: PaymentStatus) => {
 export const getStatusIcon = (status: PaymentStatus) => {
   switch (status) {
     case 'pending':
-      return Cross;
+      return Pause;
     case 'succeeded':
-      return Check;
+      return Circle;
     case 'done':
       return Check;
     case 'refunded':
-      return Cross;
+      return Square;
     case 'removed':
       return Cross;
   }

--- a/src/payments/components/Status/status.less
+++ b/src/payments/components/Status/status.less
@@ -1,0 +1,4 @@
+.icon {
+  width: 22px;
+  margin-right: 4px;
+}

--- a/src/payments/components/Transactions/CreateTransaction/StripeForm.tsx
+++ b/src/payments/components/Transactions/CreateTransaction/StripeForm.tsx
@@ -12,7 +12,9 @@ import {
 
 import style from './createTransaction.less';
 
-const ABOUT_CREATE_TRANSACTION = md`## Legg til Saldo`;
+const ABOUT_CREATE_TRANSACTION = md`
+## Legg til Saldo
+`;
 
 export interface IProps extends ReactStripeElements.InjectedStripeProps {}
 

--- a/src/payments/components/Transactions/CreateTransaction/StripeForm.tsx
+++ b/src/payments/components/Transactions/CreateTransaction/StripeForm.tsx
@@ -1,0 +1,80 @@
+import React, { ChangeEvent, FC, FormEvent, useState } from 'react';
+import { CardElement, injectStripe, ReactStripeElements } from 'react-stripe-elements';
+
+import { md } from 'common/components/Markdown';
+import { useToast } from 'core/utils/toast/useToast';
+import {
+  createPaymentMethod,
+  createTransaction,
+  handleCardVerification,
+  IGenericReturn,
+} from 'payments/api/paymentTransaction';
+
+import style from './createTransaction.less';
+
+const ABOUT_CREATE_TRANSACTION = md`## Legg til Saldo`;
+
+export interface IProps extends ReactStripeElements.InjectedStripeProps {}
+
+const SALDO_VALUES = [100, 200, 500];
+
+export const Form: FC<IProps> = ({ stripe }) => {
+  const [displayError] = useToast({ type: 'error', duration: 12000 });
+  const [displayMessage] = useToast({ duration: 12000, overwrite: true });
+  const [processing, setProcessing] = useState(false);
+  const [amount, setAmount] = useState(SALDO_VALUES[0]);
+
+  const handleResponse = ({ status, message }: IGenericReturn) => {
+    if (status === 'error') {
+      displayError(message);
+    } else if (status === 'success' || status === 'pending') {
+      displayMessage(message);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!stripe) {
+      displayError('Det skjedde noe galt med koblingen til betalingssystemet.');
+      return;
+    }
+    setProcessing(true);
+    const methodResponse = await createPaymentMethod(stripe);
+
+    handleResponse(methodResponse);
+    if (methodResponse.status === 'success' && methodResponse.paymentMethod) {
+      const transactionResponse = await createTransaction(amount, methodResponse.paymentMethod);
+      handleResponse(transactionResponse);
+      if (transactionResponse.status === 'pending' && transactionResponse.transaction) {
+        const verifyResponse = await handleCardVerification(stripe, transactionResponse.transaction);
+        handleResponse(verifyResponse);
+      }
+    }
+    setProcessing(false);
+  };
+
+  const onAmountChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setAmount(Number(event.target.value));
+  };
+
+  return (
+    <div className={style.container}>
+      {ABOUT_CREATE_TRANSACTION}
+      <form onSubmit={handleSubmit} className={style.form}>
+        <CardElement style={{ base: { fontSize: '18px' } }} />
+        <div className={style.subForm}>
+          <select onChange={onAmountChange} value={amount}>
+            {SALDO_VALUES.map((value) => (
+              <option value={value} key={value}>{`${value} kr`}</option>
+            ))}
+          </select>
+          <button disabled={processing} className={style.payButton}>
+            Betal
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export const StripeForm = injectStripe(Form);

--- a/src/payments/components/Transactions/CreateTransaction/createTransaction.less
+++ b/src/payments/components/Transactions/CreateTransaction/createTransaction.less
@@ -1,0 +1,54 @@
+@import '~common/less/colors.less';
+@import '~common/less/mixins.less';
+@import '~common/less/constants.less';
+
+.container {
+  .owCard();
+  width: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+  display: grid;
+  gap: @owFontS;
+}
+
+.form {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 4fr 3fr;
+  gap: @owFontS;
+
+  @media screen and (max-width: @owMobileBreakpoint) {
+    grid-template-columns: 1fr;
+  }
+
+  /* stylelint-disable selector-class-pattern */
+  input,
+  select,
+  :global(.StripeElement) {
+    .owBorderRadius();
+    padding: 10px;
+    border: 2px solid @offWhite;
+    background: transparent;
+  }
+  /* stylelint-enable */
+}
+
+.subForm {
+  width: 100%;
+  display: grid;
+  gap: @owFontS;
+  grid-template-columns: 2fr 1fr;
+}
+
+.payButton {
+  .owBorderRadius();
+  background: @green;
+  color: #fff;
+  font-size: @owFontM;
+  font-weight: 400;
+  letter-spacing: 1px;
+
+  &:disabled {
+    background: @gray;
+  }
+}

--- a/src/payments/components/Transactions/CreateTransaction/index.tsx
+++ b/src/payments/components/Transactions/CreateTransaction/index.tsx
@@ -1,12 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Elements, StripeProvider } from 'react-stripe-elements';
 
 import { STRIPE_KEY_TRIKOM } from 'common/constants/stripe';
 import { StripeForm } from './StripeForm';
 
 export const CreateTransaction = () => {
+  const [stripe, setStripe] = useState<stripe.Stripe | null>(null);
+
+  const initStripe = () => {
+    if (window.Stripe) {
+      setStripe(window.Stripe(STRIPE_KEY_TRIKOM));
+    }
+  };
+
+  useEffect(() => {
+    if (window.Stripe) {
+      initStripe();
+    } else {
+      const script = document.querySelector('#stripe-js');
+      if (script) {
+        script.addEventListener('load', initStripe);
+      }
+    }
+  }, []);
+
   return (
-    <StripeProvider apiKey={STRIPE_KEY_TRIKOM}>
+    <StripeProvider stripe={stripe}>
       <Elements>
         <StripeForm />
       </Elements>

--- a/src/payments/components/Transactions/CreateTransaction/index.tsx
+++ b/src/payments/components/Transactions/CreateTransaction/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Elements, StripeProvider } from 'react-stripe-elements';
+
+import { STRIPE_KEY_TRIKOM } from 'common/constants/stripe';
+import { StripeForm } from './StripeForm';
+
+export const CreateTransaction = () => {
+  return (
+    <StripeProvider apiKey={STRIPE_KEY_TRIKOM}>
+      <Elements>
+        <StripeForm />
+      </Elements>
+    </StripeProvider>
+  );
+};

--- a/src/payments/components/Transactions/Purchases.tsx
+++ b/src/payments/components/Transactions/Purchases.tsx
@@ -1,0 +1,70 @@
+import { DateTime } from 'luxon';
+import React, { FC, useEffect, useState } from 'react';
+
+import { getUser } from 'authentication/api';
+import Spinner from 'common/components/Spinner';
+import { Table } from 'common/components/Table';
+import { useToast } from 'core/utils/toast/useToast';
+import { getOrders } from 'profile/api/orders';
+import { IOrderLine } from 'profile/models/Orders';
+
+import { Paid } from '../Paid';
+import style from './transactions.less';
+
+export const Purchases: FC = () => {
+  const [ready, setReady] = useState(false);
+  const [orders, setOrders] = useState<IOrderLine[]>([]);
+  const [displayMessage] = useToast();
+
+  const fetchOrders = async () => {
+    try {
+      const user = await getUser();
+      const newOrders = await getOrders(user);
+      setOrders(newOrders);
+    } catch (err) {
+      displayMessage('Det skjedde en feil under hentingen av ordre');
+    }
+    setReady(true);
+  };
+
+  useEffect(() => {
+    fetchOrders();
+  }, []);
+
+  const sortedOrders = orders.sort((a, b) => Date.parse(b.datetime) - Date.parse(a.datetime));
+
+  return (
+    <div className={style.transactionsContainer}>
+      {ready ? (
+        <Table headers={['Produkt', 'Pris', 'Antall', 'Betalt', 'Dato']} title="Tidligere kjøp">
+          {sortedOrders.map((order) => (
+            <OrderLine key={order.datetime} orderLine={order} />
+          ))}
+        </Table>
+      ) : (
+        <Spinner />
+      )}
+    </div>
+  );
+};
+
+export interface IOrderlineProps {
+  orderLine: IOrderLine;
+}
+
+const OrderLine: FC<IOrderlineProps> = ({ orderLine }) => {
+  const formattedDate = DateTime.fromISO(orderLine.datetime).toLocaleString(DateTime.DATETIME_MED);
+  return (
+    <>
+      {orderLine.orders.map((order) => (
+        <tr key={`${orderLine.datetime}-${order.content_object.name}`}>
+          <td className={style.centerText}>{order.content_object.name}</td>
+          <td className={style.centerText}>{`${Number(order.price)} kr`}</td>
+          <td className={style.centerText}>{order.quantity}</td>
+          <td className={style.centerIcon}>{<Paid paid={orderLine.paid} />}</td>
+          <td className={style.centerText}>{formattedDate}</td>
+        </tr>
+      ))}
+    </>
+  );
+};

--- a/src/payments/components/Transactions/Transaction.tsx
+++ b/src/payments/components/Transactions/Transaction.tsx
@@ -1,0 +1,30 @@
+import { DateTime } from 'luxon';
+import React, { FC } from 'react';
+
+import { IPaymentTransaction } from 'payments/models/PaymentTransaction';
+
+import { Status } from '../Status';
+import style from './transactions.less';
+import { TypeIcon } from './TypeIcon';
+
+export interface IProps {
+  transaction: IPaymentTransaction;
+}
+
+export const Transaction: FC<IProps> = ({ transaction }) => {
+  const formattedDate = DateTime.fromISO(transaction.datetime).toLocaleString(DateTime.DATETIME_MED);
+  return (
+    <tr>
+      <td className={style.centerText}>{formattedDate}</td>
+      <td className={style.centerText}>{`${transaction.amount} kr`}</td>
+      <td className={style.centerIcon}>
+        <Status status={transaction.status} />
+      </td>
+      <td>
+        <div className={style.centerIcon}>
+          <TypeIcon type={transaction.used_stripe ? 'stripe' : 'cash'} />
+        </div>
+      </td>
+    </tr>
+  );
+};

--- a/src/payments/components/Transactions/TypeIcon.tsx
+++ b/src/payments/components/Transactions/TypeIcon.tsx
@@ -1,0 +1,23 @@
+import { faStripe } from '@fortawesome/free-brands-svg-icons/faStripe';
+import { faMoneyBillAlt } from '@fortawesome/free-regular-svg-icons/faMoneyBillAlt';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import React, { FC } from 'react';
+
+import { PaymentType } from 'payments/models/Payment';
+
+export interface IProps {
+  type: PaymentType;
+}
+
+const getPaymentTypeIcon = (type: PaymentType) => {
+  switch (type) {
+    case 'cash':
+      return <Icon icon={faMoneyBillAlt} title="Kontant" size="2x" />;
+    case 'stripe':
+      return <Icon icon={faStripe} title="Stripe" size="2x" />;
+  }
+};
+
+export const TypeIcon: FC<IProps> = ({ type }) => {
+  return getPaymentTypeIcon(type);
+};

--- a/src/payments/components/Transactions/index.tsx
+++ b/src/payments/components/Transactions/index.tsx
@@ -1,0 +1,44 @@
+import React, { FC, useEffect, useState } from 'react';
+
+import Spinner from 'common/components/Spinner';
+import { Table } from 'common/components/Table';
+import { useToast } from 'core/utils/toast/useToast';
+import { getAllTransactions } from 'payments/api/paymentTransaction';
+import { IPaymentTransaction } from 'payments/models/PaymentTransaction';
+
+import { Transaction } from './Transaction';
+import style from './transactions.less';
+
+export const Transactions: FC = () => {
+  const [ready, setReady] = useState(false);
+  const [transactions, setTransactions] = useState<IPaymentTransaction[]>([]);
+  const [addMessage] = useToast({ type: 'error', duration: 10000 });
+
+  const fetchTransactions = async () => {
+    try {
+      const data = await getAllTransactions();
+      setTransactions(data);
+    } catch (err) {
+      addMessage(String(err));
+    }
+    setReady(true);
+  };
+
+  useEffect(() => {
+    fetchTransactions();
+  }, []);
+
+  return (
+    <div className={style.transactionsContainer}>
+      {ready ? (
+        <Table headers={['Dato', 'Verdi', 'Betalt', 'Betalingsløsning']} title="Innskudd">
+          {transactions.map((transaction) => (
+            <Transaction key={transaction.datetime} transaction={transaction} />
+          ))}
+        </Table>
+      ) : (
+        <Spinner />
+      )}
+    </div>
+  );
+};

--- a/src/payments/components/Transactions/transactions.less
+++ b/src/payments/components/Transactions/transactions.less
@@ -1,0 +1,24 @@
+@import '~common/less/colors.less';
+@import '~common/less/mixins.less';
+@import '~common/less/constants.less';
+
+.transactionDetails {
+  margin-top: 10px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.transactionsContainer {
+  display: grid;
+  gap: 12px;
+}
+
+.centerText {
+  text-align: center;
+  vertical-align: middle;
+}
+
+.centerIcon {
+  display: flex;
+  justify-content: center;
+}

--- a/src/payments/index.tsx
+++ b/src/payments/index.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react';
+
+import { md } from 'common/components/Markdown';
+import { Page, Pane } from 'common/components/Panes';
+
+import { Transactions } from './components/Transactions';
+import { CreateTransaction } from './components/Transactions/CreateTransaction';
+import { Purchases } from './components/Transactions/Purchases';
+
+const ABOUT_TRANSACTIONS = md`
+  # Transaksjoner
+
+  Transaksjoner er innskuddene du har gjort til saldo hos Online.
+  Dette er pengene du kan bruke i kiosken (Nibble) på Onlinekontoret.
+`;
+
+export const Payments: FC = () => {
+  return (
+    <Page>
+      <Pane>{ABOUT_TRANSACTIONS}</Pane>
+      <CreateTransaction />
+      <Transactions />
+      <Purchases />
+    </Page>
+  );
+};

--- a/src/payments/models/Payment.ts
+++ b/src/payments/models/Payment.ts
@@ -1,0 +1,17 @@
+export type PaymentStatus = 'pending' | 'succeeded' | 'done' | 'refunded' | 'removed';
+
+/** Payment Types are currently implemented by a 'used_stripe' variable. */
+export type PaymentType = 'cash' | 'stripe';
+
+export interface IPaymentPrice {
+  id: number;
+  price: number;
+  description: string;
+}
+
+export interface IPayment {
+  id: number;
+  payment_prices: IPaymentPrice[];
+  description: string;
+  stripe_public_key: string;
+}

--- a/src/payments/models/PaymentRelation.ts
+++ b/src/payments/models/PaymentRelation.ts
@@ -1,0 +1,26 @@
+import { IPayment, IPaymentPrice, PaymentStatus } from './Payment';
+
+export interface IPaymentRelation {
+  payment: IPayment;
+  payment_price: IPaymentPrice;
+  datetime: string;
+  refunded: boolean;
+  payment_intent_secret: string | null;
+  status: PaymentStatus;
+}
+
+/** Data sent to the server to paying for a payment */
+export interface ICreatePaymentRelation {
+  /** ID of the Payment */
+  payment: number;
+  /** ID of the PaymentPrice */
+  payment_price: number;
+  /** ID of the Stripe PaymentMethod */
+  payment_method_id: string;
+}
+
+/** Data sent to the server for verifying a payment in progress */
+export interface IUpdatePaymentRelation {
+  /** ID of the Stripe PaymentIntent */
+  payment_intent_id: string;
+}

--- a/src/payments/models/PaymentTransaction.ts
+++ b/src/payments/models/PaymentTransaction.ts
@@ -1,0 +1,35 @@
+import { PaymentStatus } from './Payment';
+
+export interface IPaymentTransactionsItem {
+  name: string;
+  price: number;
+  amount: number;
+}
+
+export interface IPaymentTransaction {
+  id: number;
+  amount: number;
+  used_stripe: boolean;
+  datetime: string;
+  status: PaymentStatus;
+  payment_intent_secret: string | null;
+  description: string;
+  items: IPaymentTransactionsItem[];
+}
+
+/**
+ * Data sent to the server to create a PaymentTransaction.
+ * Typically used for adding and amount to user Saldo.
+ */
+export interface ICreatePaymentTransaction {
+  /** Amount to add in NOK (_not_ øre!) */
+  amount: number;
+  /** Id of the Stripe PaymentMethod */
+  payment_method_id: string;
+}
+
+/** Data sent to the server to verify a PaymentStatus:'pending' PaymentTransaction */
+export interface IUpdatePaymentTransaction {
+  /** ID of the Stripe PaymentIntent */
+  payment_intent_id: string;
+}

--- a/src/payments/models/Stripe.ts
+++ b/src/payments/models/Stripe.ts
@@ -1,0 +1,42 @@
+export interface IPaymentIntent {
+  /** Stripe Object ID */
+  id: string;
+  /** Stripe Object Type */
+  object: string;
+  billing_details: {
+    address: {
+      city: string | null;
+      country: string | null;
+      line1: string | null;
+      line2: string | null;
+      postal_code: string | null;
+      state: string | null;
+    };
+    email: string | null;
+    name: string | null;
+    phone: string | number | null;
+  };
+  card: {
+    brand: string;
+    checks: {
+      address_line1_check: null;
+      address_postal_code_check: null;
+      cvc_check: string | null;
+    };
+    country: string;
+    exp_month: number;
+    exp_year: number;
+    funding: string;
+    generated_from: null;
+    last4: string;
+    three_d_secure_usage: {
+      supported: boolean;
+    };
+    wallet: null;
+  };
+  created: number;
+  customer: null;
+  livemode: false;
+  metadata: {};
+  type: string;
+}

--- a/src/profile/components/Settings/Privacy/index.tsx
+++ b/src/profile/components/Settings/Privacy/index.tsx
@@ -25,8 +25,8 @@ const Privacy: FC = () => {
   const { user } = useContext(UserContext);
   const [options, setOptions] = useState<PrivacyOptions>(INITIAL_STATE);
 
-  const { addMessage: addSuccessMessage } = useToast({ overwrite: true, type: 'success', duration: 3000 });
-  const { addMessage: addErrorMessage } = useToast({ overwrite: true, type: 'error', duration: 3000 });
+  const [displaySuccess] = useToast({ overwrite: true, type: 'success', duration: 3000 });
+  const [displayError] = useToast({ overwrite: true, type: 'error', duration: 3000 });
 
   /** Fetch Privacy options from server and put into state. */
   const fetchInitial = async () => {
@@ -42,9 +42,9 @@ const Privacy: FC = () => {
       const serverOptions = await putPrivacyOptions(newOptions, user);
       if (serverOptions) {
         setOptions(serverOptions);
-        addSuccessMessage({ content: 'Innstillingen ble oppdatert.' });
+        displaySuccess('Innstillingen ble oppdatert.');
       } else {
-        addErrorMessage({ content: 'Det skjedde noe galt under uppdateringen av innstillingen.' });
+        displayError('Det skjedde noe galt under uppdateringen av innstillingen.');
       }
     }
   };

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -146,6 +146,7 @@ const wrapHtml = (dom: string, prefetcher: PrefetchState) => {
         </script>
         ${scripts.join('\n')}
       </body>
+      <script id="stripe-js" src="https://js.stripe.com/v3/" async></script>
     </html>
   `;
 };

--- a/static/index.html
+++ b/static/index.html
@@ -10,4 +10,5 @@
   <body>
     <div id="root"></div>
   </body>
+  <script id="stripe-js" src="https://js.stripe.com/v3/" async></script>
 </html>

--- a/types/Stripe.d.ts
+++ b/types/Stripe.d.ts
@@ -1,0 +1,37 @@
+import { ReactStripeElements as Base } from 'react-stripe-elements';
+
+/**
+ * Extend Stripe type definitions because they are not up to date with what we need.
+ */
+
+declare module 'react-stripe-elements' {
+
+  export namespace ReactStripeElements {
+    // tslint:disable-next-line interface-name
+    interface StripeProps {
+      paymentRequest: stripe.Stripe['paymentRequest'];
+      createSource(sourceData?: Base.SourceOptions): Promise<Base.SourceResponse>;
+      createToken(options?: Base.TokenOptions): Promise<Base.PatchedTokenResponse>;
+      // The stripe codebase basically uses 'any', these methods are hard to type...
+      // tslint:disable-next-line no-any
+      createPaymentMethod(paymentMethodType: string, elementOrData?: any, maybeData?: MaybeData): Promise<any>;
+    }
+  }
+
+  // tslint:disable-next-line interface-name
+  export interface MaybeData {
+    billing_details?: {
+      address?: {
+        city?: string;
+        country?: string;
+        line1?: string;
+        line2?: string;
+        postal_code?: number;
+        state: string;
+      },
+      email?: string;
+      name?: string;
+      phone?: string;
+    };
+  }
+}

--- a/types/Stripe.d.ts
+++ b/types/Stripe.d.ts
@@ -1,6 +1,16 @@
 import { ReactStripeElements as Base } from 'react-stripe-elements';
 
 /**
+ * The Stripe script adds a global Stripe object to window when it loads.
+ */
+declare global {
+  // tslint:disable-next-line interface-name
+  interface Window {
+    Stripe?: (apiKey: string) => stripe.Stripe;
+  }
+}
+
+/**
  * Extend Stripe type definitions because they are not up to date with what we need.
  */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,31 +852,38 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
   integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
-"@fortawesome/fontawesome-common-types@^0.2.17":
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.17.tgz#d8c36e6f6f3b3415fa1f83eaffe4f41bd313715c"
-  integrity sha512-DEYsEb/iiGVoMPQGjhG2uOylLVuMzTxOxysClkabZ5n80Q3oFDWGnshCLKvOvKoeClsgmKhWVrnnqvsMI1cAbw==
+"@fortawesome/fontawesome-common-types@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz#c0d8f073a5116b2de0a2c8a7aba66093a6956ce7"
+  integrity sha512-834DrzO2Ne3upCW+mJJPC/E6BsFcj+2Z1HmPIhbpbj8UaKmXWum4NClqLpUiMetugRlHuG4jbIHNdv2/lc3c1Q==
 
 "@fortawesome/fontawesome-svg-core@^1.2.14":
-  version "1.2.17"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.17.tgz#8fce4402e824ebe99a04b1949d56d696eeae2e6d"
-  integrity sha512-TORMW/wIX2QyyGBd4XwHGPir4/0U18Wxf+iDBAUW3EIJ0/VC/ZMpJOiyiCe1f8g9h0PPzA7sqVtl8JtTUtm4uA==
+  version "1.2.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.18.tgz#c26cbded461895ebe260f0dea771ca29d8cb3517"
+  integrity sha512-1vyLWVQqxQ8q8bA2zgZcljk3RkeELlDJ757ymLk+ebK019AFgEFH5kTnR5OMN1SFsTwW1OHlFQO3VufdeCg/Gg==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.17"
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
+
+"@fortawesome/free-brands-svg-icons@^5.8.2":
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.8.2.tgz#e68a509c986d5d197cc5bd9ae8d966eff513468d"
+  integrity sha512-nhEWctDOP6f+Ka10LXAFoF+6mtWidC2iQgTBGRGgydmhBtcIEwyxWVx5wQHa86A1zAMi5TnipDAYQs2qn7DD6A==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
 
 "@fortawesome/free-regular-svg-icons@^5.7.2":
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.8.1.tgz#9477a973fe3f681f871375fa95ff32a87dcb5111"
-  integrity sha512-U+tFjDyQpVdD0UPWoKRBVLhh0J1/q3iaWDrnxNMJKuKRmerc4d0jfiZdM2X7agOTcG7amvcllRBiWCu2FwYlMA==
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.8.2.tgz#f61c603c73695a41bcee9d6f9d44e2ca4829f151"
+  integrity sha512-499WODlsDcXA9hM+Y3ZqoWj1kKhVLCHS8PnJs3zEaoPr5W6yrE9Jnp3C9Hb9KpwnRMh3IRXZ3XqxyUaQFMMRFw==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.17"
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
 
 "@fortawesome/free-solid-svg-icons@^5.7.1":
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.8.1.tgz#086c70f95b34a4bcf6f50ff1078d46e53486eb52"
-  integrity sha512-FUcxR75PtMOo3ihRHJOZz64IsWIVdWgB2vCMLJjquTv487wVVCMH5H5gWa72et2oI9lKKD2jvjQ+y+7mxhscVQ==
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.8.2.tgz#aa2f042f73aca43eb4a26149907e63bf26d2e31c"
+  integrity sha512-5tF6WOFlqqO95zY5ukSB6jliDa3jnk1p5L4K/a58ccDFsbjSkhfGuvZkRkeWxH8uMms81pZd6yQTwQrkedeJmg==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.17"
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
 
 "@fortawesome/react-fontawesome@^0.1.4":
   version "0.1.4"
@@ -1407,6 +1414,14 @@
     "@types/react-dom" "*"
     "@types/react-transition-group" "*"
 
+"@types/react-stripe-elements@^1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@types/react-stripe-elements/-/react-stripe-elements-1.1.10.tgz#c224a6bc1b1638ff94b84c881758d534defeff64"
+  integrity sha512-FcGRb2Rwolgx6/epqnZ4ZOMHTx6wUBhkVFWWvob46fBBece3cvxCaP/vPFhf3+dUHfQeITCjMEavdB6rrbZFzg==
+  dependencies:
+    "@types/react" "*"
+    "@types/stripe-v3" "*"
+
 "@types/react-transition-group@*":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.9.0.tgz#2a74a885432d673a93a2c93c34ce5dbf9f1426f8"
@@ -1444,6 +1459,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/stripe-v3@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/stripe-v3/-/stripe-v3-3.1.0.tgz#e4337d8dcd57a4289e8ed56096e61d91454b67cf"
+  integrity sha512-cau5Y5xYsn7qOSgpzk67cJ5R7cqI9q7ZsR6NttvkoQqYPhnd4RC2+I5WmY/hEew0EBOrFwyObBLbZHU7CmyVjg==
 
 "@types/tapable@*":
   version "1.0.4"
@@ -7861,6 +7881,13 @@ react-select@^2.4.2:
     raf "^3.4.0"
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
+
+react-stripe-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-stripe-elements/-/react-stripe-elements-3.0.0.tgz#8b5e354e6e421b85f909329c9818a719b132410a"
+  integrity sha512-ouGHPmPhdg7KUTOFVuYIr0UWVgBjG5CqmOn9/y0vaJICryPB6llkiOGeUXKrac7fu1/vtPdn8t/4JKnbi8PT8g==
+  dependencies:
+    prop-types "^15.5.10"
 
 react-test-renderer@^16.0.0-0:
   version "16.8.6"


### PR DESCRIPTION
This PR creates a _Payments_ module to handle all payment related things.
It also sets up general support for usage of Stripe.

Depends on #263 and https://github.com/dotkom/onlineweb4/pull/2272

The module displays:
- A simple form for adding money to saldo with Stripe integration.
- All transactions for adding money to user saldo.
- All purchases in Nibble ordered by purchases date.

Furthers progress on #206
Resolves #253  

*Note: Requires a new deployment of OW4 with some small fixes to payments API code*

![saldo-payment](https://user-images.githubusercontent.com/14319313/58479533-c55fb600-8158-11e9-90f0-2abb61c17188.gif)
