### PR TITLE
Add lacking trailing slash, that made API-auth not work in Safari

### DIFF
--- a/src/profile/api/orders.ts
+++ b/src/profile/api/orders.ts
@@ -2,7 +2,7 @@ import { IAuthUser } from 'authentication/models/User';
 import { getAllPages } from 'common/utils/api';
 import { IOrderLine } from 'profile/models/Orders';
 
-const API_URL = '/api/v1/profile/orders';
+const API_URL = '/api/v1/profile/orders/';
 
 export const getOrders = async (user: IAuthUser): Promise<IOrderLine[]> => {
   const results = await getAllPages<IOrderLine>(API_URL, { page_size: 80 }, { user });

--- a/types/Stripe.d.ts
+++ b/types/Stripe.d.ts
@@ -15,7 +15,6 @@ declare global {
  */
 
 declare module 'react-stripe-elements' {
-
   export namespace ReactStripeElements {
     // tslint:disable-next-line interface-name
     interface StripeProps {
@@ -38,7 +37,7 @@ declare module 'react-stripe-elements' {
         line2?: string;
         postal_code?: number;
         state: string;
-      },
+      };
       email?: string;
       name?: string;
       phone?: string;


### PR DESCRIPTION
The other changes are from Prettier Filewatcher