### PR TITLE
Add customisable data-tables

### DIFF
--- a/src/common/components/Table/DataTable.tsx
+++ b/src/common/components/Table/DataTable.tsx
@@ -1,0 +1,99 @@
+import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { getKeys } from 'common/utils/tsHacks';
+
+import style from './table.less';
+
+export type SortFunction<T> = (a: T, b: T) => number;
+
+// tslint:disable-next-line interface-over-type-literal
+export type DataTableHeaders = { [key: string]: string };
+export type DataTableSorters<H, T> = { [HeaderKey in keyof H]?: SortFunction<T> };
+
+export interface IProps<T extends {}, H extends DataTableHeaders> {
+  headers: H;
+  title?: string;
+  items: T[];
+  children: (items: T[]) => ReactNode;
+  sorters?: DataTableSorters<H, T>;
+  displayAmount?: number;
+  selectedHeader?: keyof H;
+}
+
+const BASE_SORT_FUNCTION = () => 1;
+const BASE_DISPLAY_AMOUNT = 10;
+
+export function DataTable<T extends {}, H extends {}>({
+  headers,
+  title,
+  children,
+  items,
+  sorters,
+  displayAmount = BASE_DISPLAY_AMOUNT,
+  selectedHeader: overrideSelectedHeader,
+}: IProps<T, H>) {
+  /** The selected Header is chosen as the first key in the object of headers if override is undefined */
+  const initialSelectedHeader = useMemo(() => overrideSelectedHeader || getKeys<H>(headers)[0], []);
+  const [selectedHeader, setSelectedHeader] = useState<keyof H>(initialSelectedHeader);
+  const [reversedSort, setReversedSort] = useState(false);
+
+  const [displayAll, setDisplayAll] = useState(false);
+  const toggleDisplayAll = useCallback(() => setDisplayAll((current) => !current), []);
+
+  /** Use the sorting function for the selected header, or use the default if it is not defined */
+  const sortFunction = sorters ? sorters[selectedHeader] || BASE_SORT_FUNCTION : BASE_SORT_FUNCTION;
+  /** Sort items by the selected sorting function, memoize since sorting can be expensive. */
+  const sortedItems = useMemo(() => items.sort(sortFunction), [selectedHeader]);
+  /** Order the list by acending or descending */
+  const orderedItems = reversedSort ? sortedItems.reverse() : sortedItems;
+  /** Cut down the displayed list as the last step, even a cut of list should be sorted. */
+  const displayItems = displayAll ? orderedItems : orderedItems.slice(0, displayAmount);
+
+  /**
+   * Update the selected header from props if it is redefined.
+   * Selected header can be set by the user, but if the override changes it will be updated by the app.
+   */
+  useEffect(() => {
+    if (overrideSelectedHeader) {
+      setSelectedHeader(overrideSelectedHeader);
+    }
+  }, [overrideSelectedHeader]);
+
+  /** Use callback to memoize function signature since it is always the same */
+  const handleHeaderClick = useCallback((clickedHeader: typeof selectedHeader) => {
+    setSelectedHeader((currentSelectedHeader) => {
+      if (clickedHeader === currentSelectedHeader) {
+        /** Sorting direction is toggled if the selected header is clicked */
+        setReversedSort((current) => !current);
+      } else {
+        /** Set new header as clicked and set sorting direction to default */
+        setReversedSort(false);
+        return clickedHeader;
+      }
+      return currentSelectedHeader;
+    });
+  }, []);
+
+  return (
+    <div className={style.container}>
+      <table>
+        {title ? <caption>{title}</caption> : null}
+        <thead>
+          <tr>
+            {getKeys(headers).map((header) => (
+              <th key={header as string} scope="col" onClick={() => handleHeaderClick(header)}>
+                <h3 className={style.header}>{headers[header]}</h3>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children(displayItems)}</tbody>
+      </table>
+      <div className={style.bottomContent}>
+        <button className={style.toggleButton} onClick={toggleDisplayAll}>
+          {displayAll ? `Vis færre elementer (${displayAmount})` : `Vis alle elementer (${sortedItems.length})`}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/common/components/Table/DataTable.tsx
+++ b/src/common/components/Table/DataTable.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getKeys } from 'common/utils/tsHacks';
@@ -81,7 +82,14 @@ export function DataTable<T extends {}, H extends {}>({
         <thead>
           <tr>
             {getKeys(headers).map((header) => (
-              <th key={header as string} scope="col" onClick={() => handleHeaderClick(header)}>
+              <th
+                key={header as string}
+                className={classnames({
+                  [style.selectedHeader]: header === selectedHeader,
+                })}
+                scope="col"
+                onClick={() => handleHeaderClick(header)}
+              >
                 <h3 className={style.header}>{headers[header]}</h3>
               </th>
             ))}

--- a/src/common/components/Table/DataTable.tsx
+++ b/src/common/components/Table/DataTable.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getKeys } from 'common/utils/tsHacks';
 
@@ -46,7 +46,7 @@ export function DataTable<T extends {}, H extends {}>({
   /** Sort items by the selected sorting function, memoize since sorting can be expensive. */
   const sortedItems = useMemo(() => items.sort(sortFunction), [selectedHeader]);
   /** Order the list by acending or descending */
-  const orderedItems = reversedSort ? sortedItems.reverse() : sortedItems;
+  const orderedItems = reversedSort ? sortedItems.slice().reverse() : sortedItems;
   /** Cut down the displayed list as the last step, even a cut of list should be sorted. */
   const displayItems = displayAll ? orderedItems : orderedItems.slice(0, displayAmount);
 
@@ -82,15 +82,19 @@ export function DataTable<T extends {}, H extends {}>({
         <thead>
           <tr>
             {getKeys(headers).map((header) => (
-              <th
-                key={header as string}
-                className={classnames({
-                  [style.selectedHeader]: header === selectedHeader,
-                })}
-                scope="col"
-                onClick={() => handleHeaderClick(header)}
-              >
+              <th key={header as string} scope="col" onClick={() => handleHeaderClick(header)}>
                 <h3 className={style.header}>{headers[header]}</h3>
+                <div className={style.directionContainer}>
+                  {header === selectedHeader && !reversedSort ? <Triangle /> : null}
+                </div>
+                <div
+                  className={classnames(style.headerBorder, {
+                    [style.selectedHeader]: header === selectedHeader,
+                  })}
+                />
+                <div className={classnames(style.directionContainer, style.upsideDown)}>
+                  {header === selectedHeader && reversedSort ? <Triangle /> : null}
+                </div>
               </th>
             ))}
           </tr>
@@ -105,3 +109,11 @@ export function DataTable<T extends {}, H extends {}>({
     </div>
   );
 }
+
+const Triangle: FC = () => {
+  return (
+    <svg width="100%" height="100%" viewBox="0 0 8 3">
+      <path d="M4 3L0 0L8 0L4 3Z" />
+    </svg>
+  );
+};

--- a/src/common/components/Table/index.tsx
+++ b/src/common/components/Table/index.tsx
@@ -17,6 +17,7 @@ export const Table: FC<IProps> = ({ headers, title, children }) => {
             {headers.map((header) => (
               <th key={header} scope="col">
                 <h3 className={style.header}>{header}</h3>
+                <div className={style.headerBorder} />
               </th>
             ))}
           </tr>

--- a/src/common/components/Table/table.less
+++ b/src/common/components/Table/table.less
@@ -18,10 +18,6 @@
       margin: 10px;
     }
 
-    > thead {
-      border-bottom: 0.5px solid #333;
-    }
-
     > tbody {
       th,
       td {
@@ -45,17 +41,36 @@
   }
 }
 
-.selectedHeader {
-  border-bottom: 1.5px solid #333;
-}
-
 .header {
-  padding: 16px 0;
+  padding: 10px 0;
   word-break: break-word;
   hyphens: auto;
 
   @media screen and (max-width: @owMobileBreakpoint) {
     font-size: @owFontS;
+  }
+}
+
+.headerBorder {
+  border-bottom: 0.5px solid #333;
+
+  &.selectedHeader {
+    border-bottom: 1.5px solid #333;
+  }
+}
+
+.directionContainer {
+  text-align: center;
+  height: 6px;
+  margin-bottom: -2px;
+
+  path {
+    fill: @darkGray;
+  }
+
+  &.upsideDown {
+    transform: rotate(180deg);
+    margin-top: -2px;
   }
 }
 

--- a/src/common/components/Table/table.less
+++ b/src/common/components/Table/table.less
@@ -45,6 +45,10 @@
   }
 }
 
+.selectedHeader {
+  border-bottom: 1.5px solid #333;
+}
+
 .header {
   padding: 16px 0;
   word-break: break-word;

--- a/src/common/components/Table/table.less
+++ b/src/common/components/Table/table.less
@@ -54,3 +54,18 @@
     font-size: @owFontS;
   }
 }
+
+.toggleButton {
+  border-radius: 3px;
+  padding: 10px;
+  border: 2px solid @green;
+  color: @green;
+  background: transparent;
+  cursor: pointer;
+}
+
+.bottomContent {
+  display: flex;
+  justify-content: center;
+  padding: 16px 0 0;
+}

--- a/src/payments/components/Transactions/index.tsx
+++ b/src/payments/components/Transactions/index.tsx
@@ -1,13 +1,30 @@
 import React, { FC, useEffect, useState } from 'react';
 
 import Spinner from 'common/components/Spinner';
-import { Table } from 'common/components/Table';
+import { DataTable, DataTableHeaders, DataTableSorters } from 'common/components/Table/DataTable';
 import { useToast } from 'core/utils/toast/useToast';
 import { getAllTransactions } from 'payments/api/paymentTransaction';
+import { PaymentStatus } from 'payments/models/Payment';
 import { IPaymentTransaction } from 'payments/models/PaymentTransaction';
 
 import { Transaction } from './Transaction';
 import style from './transactions.less';
+
+const tableHeaders: DataTableHeaders = {
+  datetime: 'Dato',
+  amount: 'Verdi',
+  status: 'Betalt',
+  used_stripe: 'Betalingsløsning',
+};
+
+const STATUS_SORT_ORDER: PaymentStatus[] = ['pending', 'succeeded', 'done', 'refunded', 'removed'];
+
+const tableSorters: DataTableSorters<typeof tableHeaders, IPaymentTransaction> = {
+  datetime: (a, b) => Date.parse(a.datetime) - Date.parse(b.datetime),
+  amount: (a, b) => b.amount - a.amount,
+  used_stripe: (a, b) => Number(b.used_stripe) - Number(a.used_stripe),
+  status: (a, b) => STATUS_SORT_ORDER.indexOf(b.status) - STATUS_SORT_ORDER.indexOf(a.status),
+};
 
 export const Transactions: FC = () => {
   const [ready, setReady] = useState(false);
@@ -31,11 +48,15 @@ export const Transactions: FC = () => {
   return (
     <div className={style.transactionsContainer}>
       {ready ? (
-        <Table headers={['Dato', 'Verdi', 'Betalt', 'Betalingsløsning']} title="Innskudd">
-          {transactions.map((transaction) => (
-            <Transaction key={transaction.datetime} transaction={transaction} />
-          ))}
-        </Table>
+        <DataTable
+          title="Innskudd"
+          headers={tableHeaders}
+          items={transactions}
+          sorters={tableSorters}
+          selectedHeader="datetime"
+        >
+          {(items) => items.map((transaction) => <Transaction key={transaction.datetime} transaction={transaction} />)}
+        </DataTable>
       ) : (
         <Spinner />
       )}

--- a/src/payments/components/Transactions/index.tsx
+++ b/src/payments/components/Transactions/index.tsx
@@ -20,7 +20,7 @@ const tableHeaders: DataTableHeaders = {
 const STATUS_SORT_ORDER: PaymentStatus[] = ['pending', 'succeeded', 'done', 'refunded', 'removed'];
 
 const tableSorters: DataTableSorters<typeof tableHeaders, IPaymentTransaction> = {
-  datetime: (a, b) => Date.parse(a.datetime) - Date.parse(b.datetime),
+  datetime: (a, b) => Date.parse(b.datetime) - Date.parse(a.datetime),
   amount: (a, b) => b.amount - a.amount,
   used_stripe: (a, b) => Number(b.used_stripe) - Number(a.used_stripe),
   status: (a, b) => STATUS_SORT_ORDER.indexOf(b.status) - STATUS_SORT_ORDER.indexOf(a.status),


### PR DESCRIPTION
Create a common data-table which makes handling larger amounts of data a bit easier.
Lets the developer define ways to sort the table columns, and specify the headers.

Converts transactions and orders in the payments view to data-tables for exmaples:
![data-table](https://user-images.githubusercontent.com/14319313/59367495-80cd4080-8d3c-11e9-99ef-2e986a802bcd.gif)
