### PR TITLE
fix: Ensure Stripe script exists in DOM before attaching listeners

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -6,9 +6,9 @@
     <title>Linjeforeningen Online</title>
     <link rel="manifest" href="/static/owf.webmanifest">
     <!-- Latest compiled and minified CSS -->
+    <script id="stripe-js" src="https://js.stripe.com/v3/" async></script>
   </head>
   <body>
     <div id="root"></div>
   </body>
-  <script id="stripe-js" src="https://js.stripe.com/v3/" async></script>
 </html>


### PR DESCRIPTION
Fixes the Stripe card input on `/payments` disappearing after refresh until cache + cookies are cleared.

Why this always worked on the first refresh I have no clue, but it appears that the error stemmed from the Stripe object being null due to [this script tag](https://github.com/dotkom/onlineweb-frontend/blob/master/src/payments/hooks/useStripeInit.ts#L32) being `null` - possibly some sick and twisted race condition with the DOM loading?