### PR TITLE
Added settings functionality to change your password

### DIFF
--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -40,6 +40,9 @@ const performRequest = async (query: string, parameters: IQueryObject = {}, opti
   };
   const requestOptions = { ...restOptions, headers };
   const response = await fetch(url, requestOptions);
+  if (response.status === 204) {
+    return null;
+  }
   const data = await response.json();
   setCache({ content: data, options: cacheOptions, url });
   return data;

--- a/src/profile/api/password.ts
+++ b/src/profile/api/password.ts
@@ -1,6 +1,6 @@
+import { getUser } from 'authentication/api';
 import { put } from 'common/utils/api';
 import { IChangePasswordData, IChangePasswordResponse } from 'profile/models/Password';
-import { getUser } from 'authentication/api';
 
 const API_URL = '/api/v1/users/';
 

--- a/src/profile/api/password.ts
+++ b/src/profile/api/password.ts
@@ -1,12 +1,19 @@
-import { IAuthUser } from 'authentication/models/User';
 import { put } from 'common/utils/api';
-import { IChangePasswordData } from 'profile/models/Password';
+import { IChangePasswordData, IChangePasswordResponse } from 'profile/models/Password';
 import { getUser } from 'authentication/api';
 
-const API_URL = '/api/v1/users';
+const API_URL = '/api/v1/users/';
 
-export const putPasswords = async (data: IChangePasswordData) => {
-  const user = await getUser();
-  const response = await put<IChangePasswordData>({ query: API_URL + user.profile.sub, data, options: { user } });
-  return response;
+export const putPasswords = async (data: IChangePasswordData): Promise<IChangePasswordResponse | null> => {
+  try {
+    const user = await getUser();
+    const response = await put<IChangePasswordResponse, IChangePasswordData>({
+      query: API_URL + user.profile.sub + `/change_password`,
+      data,
+      options: { user },
+    });
+    return response;
+  } catch {
+    return null;
+  }
 };

--- a/src/profile/api/password.ts
+++ b/src/profile/api/password.ts
@@ -1,0 +1,12 @@
+import { IAuthUser } from 'authentication/models/User';
+import { put } from 'common/utils/api';
+import { IChangePasswordData } from 'profile/models/Password';
+import { getUser } from 'authentication/api';
+
+const API_URL = '/api/v1/users';
+
+export const putPasswords = async (data: IChangePasswordData) => {
+  const user = await getUser();
+  const response = await put<IChangePasswordData>({ query: API_URL + user.profile.sub, data, options: { user } });
+  return response;
+};

--- a/src/profile/api/password.ts
+++ b/src/profile/api/password.ts
@@ -7,12 +7,15 @@ const API_URL = '/api/v1/users/';
 export const putPasswords = async (data: IChangePasswordData): Promise<IChangePasswordResponse | null> => {
   try {
     const user = await getUser();
-    const response = await put<IChangePasswordResponse, IChangePasswordData>({
-      query: API_URL + user.profile.sub + `/change_password`,
-      data,
-      options: { user },
-    });
-    return response;
+    if (user) {
+      const response = await put<IChangePasswordResponse, IChangePasswordData>({
+        query: API_URL + user.profile.sub + `/change_password`,
+        data,
+        options: { user },
+      });
+      return response;
+    }
+    return null;
   } catch {
     return null;
   }

--- a/src/profile/components/Settings/Password/ErrorMessage.tsx
+++ b/src/profile/components/Settings/Password/ErrorMessage.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+import style from './input.less';
+
+interface IProps {
+  errors?: string[];
+}
+
+export const ErrorMessage: FC<IProps> = ({ errors }) => {
+  return (
+    <>
+      {errors
+        ? errors.map((error) => (
+            <li className={style.errorMessage}>
+              <ol>{error}</ol>
+            </li>
+          ))
+        : null}
+    </>
+  );
+};

--- a/src/profile/components/Settings/Password/PasswordForm.tsx
+++ b/src/profile/components/Settings/Password/PasswordForm.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import style from './input.less';
+import classNames from 'classnames';
+import Markdown, { md } from 'common/components/Markdown';
+import PasswordInput from './PasswordInput';
+
+const OLD_PASSWORD = md`
+### Skriv inn ditt nåverende passord
+`;
+
+const NEW_PASSWORD = md`
+### Skriv inn et nytt passord
+`;
+
+const NEW_PASSWORD_REQUIREMENTS = md`
+- Passordet ditt må bestå av minst 8 tegn.
+`;
+
+const CONFIRM_PASSWORD = md`
+### Gjenta det nye passordet
+`;
+
+const PasswordForm = () => {
+  return (
+    <form class={style.editPasswordInput}>
+      <PasswordInput source="### Skriv inn ditt nåverende passord" name="old_password" />
+    </form>
+  );
+};
+
+export default PasswordForm;

--- a/src/profile/components/Settings/Password/PasswordForm.tsx
+++ b/src/profile/components/Settings/Password/PasswordForm.tsx
@@ -1,9 +1,9 @@
-import React, { FormEvent, useState } from 'react';
-import style from './input.less';
-import PasswordInput from './PasswordInput';
 import { putPasswords } from 'profile/api/password';
 import { IChangePasswordData, IChangePasswordResponse } from 'profile/models/Password';
+import React, { FormEvent, useState } from 'react';
 import { ErrorMessage } from './ErrorMessage';
+import style from './input.less';
+import PasswordInput from './PasswordInput';
 
 const PasswordForm = () => {
   const [inputs, setInputs] = useState<IChangePasswordData>({
@@ -15,7 +15,7 @@ const PasswordForm = () => {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    let response = await putPasswords(inputs);
+    const response = await putPasswords(inputs);
     if (response) {
       setErrors(response);
     }

--- a/src/profile/components/Settings/Password/PasswordForm.tsx
+++ b/src/profile/components/Settings/Password/PasswordForm.tsx
@@ -4,6 +4,7 @@ import React, { FormEvent, useState } from 'react';
 import { ErrorMessage } from './ErrorMessage';
 import style from './input.less';
 import PasswordInput from './PasswordInput';
+import SuccessMessage from './SuccessMessage';
 
 const PasswordForm = () => {
   const [inputs, setInputs] = useState<IChangePasswordData>({
@@ -12,6 +13,7 @@ const PasswordForm = () => {
     new_password_confirm: '',
   });
   const [errors, setErrors] = useState<IChangePasswordResponse>({});
+  const [isSubmitted, setSubmitted] = useState(false);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -19,6 +21,7 @@ const PasswordForm = () => {
     if (response) {
       setErrors(response);
     }
+    setSubmitted(true);
   };
 
   const handleOnChange = (event: FormEvent<HTMLInputElement>) => {
@@ -54,6 +57,10 @@ const PasswordForm = () => {
         onChange={handleOnChange}
       />
       <ErrorMessage errors={errors.non_field_errors} />
+      <SuccessMessage
+        message="Your password has been successfully changed"
+        success={isSubmitted && Object.entries(errors).length === 0}
+      />
       <button type="submit" className={style.changePasswordButton}>
         Endre passord
       </button>

--- a/src/profile/components/Settings/Password/PasswordForm.tsx
+++ b/src/profile/components/Settings/Password/PasswordForm.tsx
@@ -1,29 +1,62 @@
-import React from 'react';
+import React, { FormEvent, useState } from 'react';
 import style from './input.less';
-import classNames from 'classnames';
-import Markdown, { md } from 'common/components/Markdown';
 import PasswordInput from './PasswordInput';
-
-const OLD_PASSWORD = md`
-### Skriv inn ditt nåverende passord
-`;
-
-const NEW_PASSWORD = md`
-### Skriv inn et nytt passord
-`;
-
-const NEW_PASSWORD_REQUIREMENTS = md`
-- Passordet ditt må bestå av minst 8 tegn.
-`;
-
-const CONFIRM_PASSWORD = md`
-### Gjenta det nye passordet
-`;
+import { putPasswords } from 'profile/api/password';
+import { IChangePasswordData, IChangePasswordResponse } from 'profile/models/Password';
+import { ErrorMessage } from './ErrorMessage';
 
 const PasswordForm = () => {
+  const [inputs, setInputs] = useState<IChangePasswordData>({
+    current_password: '',
+    new_password: '',
+    new_password_confirm: '',
+  });
+  const [errors, setErrors] = useState<IChangePasswordResponse>({});
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    let response = await putPasswords(inputs);
+    if (response) {
+      setErrors(response);
+    }
+  };
+
+  const handleOnChange = (event: FormEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    const { name, value } = event.currentTarget;
+    setInputs({
+      ...inputs,
+      [name]: value,
+    });
+  };
+
   return (
-    <form class={style.editPasswordInput}>
-      <PasswordInput source="### Skriv inn ditt nåverende passord" name="old_password" />
+    <form id={style.editPasswordInput} onSubmit={handleSubmit}>
+      <PasswordInput
+        label="Skriv inn ditt nåverende passord"
+        name="current_password"
+        requiredMessage={errors.current_password}
+        required
+        onChange={handleOnChange}
+      />
+      <PasswordInput
+        label="Skriv inn et nytt passord"
+        name="new_password"
+        requiredMessage={errors.new_password}
+        required
+        onChange={handleOnChange}
+      />
+      <PasswordInput
+        label="Gjenta det nye passordet"
+        name="new_password_confirm"
+        requiredMessage={errors.new_password_confirm}
+        required
+        onChange={handleOnChange}
+      />
+      <ErrorMessage errors={errors.non_field_errors} />
+      <button type="submit" className={style.changePasswordButton}>
+        Endre passord
+      </button>
     </form>
   );
 };

--- a/src/profile/components/Settings/Password/PasswordForm.tsx
+++ b/src/profile/components/Settings/Password/PasswordForm.tsx
@@ -58,7 +58,7 @@ const PasswordForm = () => {
       />
       <ErrorMessage errors={errors.non_field_errors} />
       <SuccessMessage
-        message="Your password has been successfully changed"
+        message="Passordet ditt har blitt endret!"
         success={isSubmitted && Object.entries(errors).length === 0}
       />
       <button type="submit" className={style.changePasswordButton}>

--- a/src/profile/components/Settings/Password/PasswordInput.tsx
+++ b/src/profile/components/Settings/Password/PasswordInput.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Markdown from 'common/components/Markdown';
+
+interface IProps {
+  mdSource: string;
+  name: string;
+}
+
+const PasswordInput = ({ mdSource, name }: IProps) => {
+  return (
+    <>
+      <Markdown source={mdSource} />
+      <input type="password" name={name} id={'id_' + name} />
+    </>
+  );
+};
+
+export default PasswordInput;

--- a/src/profile/components/Settings/Password/PasswordInput.tsx
+++ b/src/profile/components/Settings/Password/PasswordInput.tsx
@@ -1,6 +1,6 @@
-import React, { FormEvent, FC } from 'react';
-import style from './input.less';
+import React, { FC, FormEvent } from 'react';
 import { ErrorMessage } from './ErrorMessage';
+import style from './input.less';
 
 interface IProps {
   label: string;

--- a/src/profile/components/Settings/Password/PasswordInput.tsx
+++ b/src/profile/components/Settings/Password/PasswordInput.tsx
@@ -1,17 +1,22 @@
-import React from 'react';
-import Markdown from 'common/components/Markdown';
+import React, { FormEvent, FC } from 'react';
+import style from './input.less';
+import { ErrorMessage } from './ErrorMessage';
 
 interface IProps {
-  mdSource: string;
+  label: string;
   name: string;
+  requiredMessage?: string[];
+  required: boolean;
+  onChange: (event: FormEvent<HTMLInputElement>) => void;
 }
 
-const PasswordInput = ({ mdSource, name }: IProps) => {
+const PasswordInput: FC<IProps> = ({ label, name, requiredMessage, required, onChange }) => {
   return (
-    <>
-      <Markdown source={mdSource} />
-      <input type="password" name={name} id={'id_' + name} />
-    </>
+    <div className={style.passwordInput}>
+      <label htmlFor={name}>{label}</label>
+      <input type="password" name={name} required={required} onChange={onChange} minLength={8} />
+      <ErrorMessage errors={requiredMessage} />
+    </div>
   );
 };
 

--- a/src/profile/components/Settings/Password/SuccessMessage.tsx
+++ b/src/profile/components/Settings/Password/SuccessMessage.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from 'react';
+import style from './input.less';
+
+interface IProps {
+  success: boolean;
+  message: string;
+}
+
+const SuccessMessage: FC<IProps> = ({ success, message }) => {
+  return <>{success && <div className={style.successMessage}>{message}</div>}</>;
+};
+
+export default SuccessMessage;

--- a/src/profile/components/Settings/Password/index.tsx
+++ b/src/profile/components/Settings/Password/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Pane } from 'common/components/Panes';
+import PasswordForm from './PasswordForm';
+
+const Password = () => {
+  return (
+    <Pane>
+      <PasswordForm />
+    </Pane>
+  );
+};
+
+export default Password;

--- a/src/profile/components/Settings/Password/index.tsx
+++ b/src/profile/components/Settings/Password/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Pane } from 'common/components/Panes';
+import React from 'react';
 import PasswordForm from './PasswordForm';
 
 const Password = () => {

--- a/src/profile/components/Settings/Password/input.less
+++ b/src/profile/components/Settings/Password/input.less
@@ -1,0 +1,21 @@
+@import '~common/less/colors.less';
+
+@inputHeight: 42px;
+
+.editPasswordInput {
+  display: grid;
+  width: 100%;
+  height: 100%;
+
+  input,
+  button {
+    height: 100%;
+    width: 100%;
+  }
+
+  input {
+    box-sizing: border-box;
+    border: @offWhite solid 2px;
+    height: @inputHeight;
+  }
+}

--- a/src/profile/components/Settings/Password/input.less
+++ b/src/profile/components/Settings/Password/input.less
@@ -47,3 +47,8 @@
   margin-left: 15px;
   font-size: 14px;
 }
+
+.successMessage {
+  color: @green;
+  font-size: 14px;
+}

--- a/src/profile/components/Settings/Password/input.less
+++ b/src/profile/components/Settings/Password/input.less
@@ -24,7 +24,7 @@
     border: @offWhite solid 2px;
     height: @inputHeight;
     width: 100%;
-    margin: 10px 0 5px 0;
+    margin: 10px 0 5px;
   }
 }
 

--- a/src/profile/components/Settings/Password/input.less
+++ b/src/profile/components/Settings/Password/input.less
@@ -1,21 +1,49 @@
 @import '~common/less/colors.less';
-
+@import '~common/less/constants.less';
+@import '~common/less/mixins.less';
 @inputHeight: 42px;
 
-.editPasswordInput {
-  display: grid;
+#editPasswordInput {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
+}
 
-  input,
-  button {
-    height: 100%;
+.passwordInput {
+  margin-bottom: 15px;
+
+  label {
+    font-size: 19px;
     width: 100%;
   }
 
   input {
+    padding: 5px;
     box-sizing: border-box;
     border: @offWhite solid 2px;
     height: @inputHeight;
+    width: 100%;
+    margin: 10px 0 5px 0;
   }
+}
+
+.changePasswordButton {
+  border-radius: 3px;
+  background: @green;
+  color: #fff;
+  font-size: @owFontM;
+  font-weight: 400;
+  letter-spacing: 1px;
+  height: 44px;
+  width: 100%;
+  cursor: pointer;
+  margin-top: 44px;
+}
+
+.errorMessage {
+  color: @red;
+  width: 100%;
+  margin-left: 15px;
+  font-size: 14px;
 }

--- a/src/profile/components/Settings/index.tsx
+++ b/src/profile/components/Settings/index.tsx
@@ -9,11 +9,11 @@ import AccessCard from './AccessCard';
 import Mails from './Mails';
 import Menu from './Menu';
 import Notifications from './Notifications';
+import Password from './Password';
 import Penalties from './Penalties';
 import Privacy from './Privacy';
 import style from './settings.less';
 import SettingsInfo from './SettingsInfo';
-import Password from './Password';
 
 const BASE_ROUTE = '/profile/settings';
 

--- a/src/profile/components/Settings/index.tsx
+++ b/src/profile/components/Settings/index.tsx
@@ -13,6 +13,7 @@ import Penalties from './Penalties';
 import Privacy from './Privacy';
 import style from './settings.less';
 import SettingsInfo from './SettingsInfo';
+import Password from './Password';
 
 const BASE_ROUTE = '/profile/settings';
 
@@ -33,7 +34,7 @@ const Settings = (_: IProfileProps) => {
       <SettingsRoute path={routes.penalties} view={Penalties} />
       <SettingsRoute path={routes.privacy} view={Privacy} />
       <SettingsRoute path={routes.mail} view={Mails} />
-      <SettingsRoute path={routes.password} view={Privacy} />
+      <SettingsRoute path={routes.password} view={Password} />
       <SettingsRoute path={routes.accessCard} view={AccessCard} />
       <SettingsRoute path={routes.notifications} view={Notifications} />
       <Route path="*" render={() => <HttpError code={404} text="Undersiden du leter etter finnes ikke" />} />

--- a/src/profile/models/Password.ts
+++ b/src/profile/models/Password.ts
@@ -1,0 +1,5 @@
+export interface IChangePasswordData {
+  current_password: string;
+  new_password: string;
+  new_password_retype: string;
+}

--- a/src/profile/models/Password.ts
+++ b/src/profile/models/Password.ts
@@ -1,5 +1,12 @@
 export interface IChangePasswordData {
   current_password: string;
   new_password: string;
-  new_password_retype: string;
+  new_password_confirm: string;
+}
+
+export interface IChangePasswordResponse {
+  current_password?: string[];
+  new_password?: string[];
+  new_password_confirm?: string[];
+  non_field_errors?: string[];
 }


### PR DESCRIPTION
You're now able to change you user password on OWF :tada: 

Here are some images

### How the change password form usually look
![editPassword1](https://user-images.githubusercontent.com/41551253/66528685-2b921780-eb01-11e9-904b-7c5dbe122198.png)
### How it looks when you have not typed 8 characters (8 is min for our passwords)
![editPassword2](https://user-images.githubusercontent.com/41551253/66528692-2f259e80-eb01-11e9-9fe7-b57d7c5e68e1.png)
### How it looks when you submit with wrong current password or retype the password wrong
![editPassword3](https://user-images.githubusercontent.com/41551253/66528693-2f259e80-eb01-11e9-84b6-77b09faed068.png)

## Issues
So what issues do we have? Guess what i had to wrap my PUT request inside of a try catch because when the password successfully changes it doesnt return anything, which means the PUT request tries to make nothing into json === error! Our PUT request expects a response, usually the data we sent. However responding with the password you just typed is pretty stupid. What we have to do is to rewrite our PUT request. This error when it returns nothing makes it also a bit difficult for us to display a message that the user sucessfully changed their password because we dont know if the "try catch" catches the empty response, or an actual error.
