### PR TITLE
Style input-type search correctly for Safari

### DIFF
--- a/src/common/components/Forms/SearchInput/search.less
+++ b/src/common/components/Forms/SearchInput/search.less
@@ -20,3 +20,7 @@
     background: darken(@pageBackground, 5%);
   }
 }
+
+input[type="search"] {
+  -webkit-appearance: textfield;
+}

--- a/src/common/components/Forms/SearchInput/search.less
+++ b/src/common/components/Forms/SearchInput/search.less
@@ -20,7 +20,3 @@
     background: darken(@pageBackground, 5%);
   }
 }
-
-input[type="search"] {
-  -webkit-appearance: textfield;
-}

--- a/src/core/less/core.less
+++ b/src/core/less/core.less
@@ -96,3 +96,7 @@ blockquote,
 li {
   line-height: 1.5;
 }
+
+input[type='search'] {
+  appearance: textfield;
+}


### PR DESCRIPTION
Because Safari styles the `<input type="search">` element differently
How it currently looks in Safari:
![image](https://user-images.githubusercontent.com/36937807/66561218-5a3bdc80-eb59-11e9-9665-0c631db6a133.png)
How it looks with this change:
![image](https://user-images.githubusercontent.com/36937807/66561284-7f304f80-eb59-11e9-898e-3d218b0a0180.png)


This makes no functional difference