### PR TITLE
Create a resource system to make API requests easier

### DIFF
--- a/src/career/api/index.ts
+++ b/src/career/api/index.ts
@@ -1,5 +1,5 @@
 import { ICareerOpportunity, IEmployment, ILocation, ISelectable, TagTypes } from 'career/models/Career';
-import { get, IAPIData } from 'common/utils/api';
+import { listResource, retrieveResource } from 'common/resources';
 import { ICompany } from 'core/models/Company';
 
 const API_URL = '/api/v1/career/';
@@ -12,9 +12,14 @@ export type FilterJobs = [
   Array<ISelectable<ILocation>>
 ];
 
-export const getCareerOpportunities = async (): Promise<FilterJobs> => {
-  const { results } = await get<IAPIData<ICareerOpportunity>>(API_URL, { format: 'json' });
-  return configureFilters(results);
+export const listCareerOpportunities = listResource<ICareerOpportunity>(API_URL);
+
+export const getCareerOpportunities = async () => {
+  const response = await listCareerOpportunities();
+  if (response.status === 'success') {
+    return configureFilters(response.data.results);
+  }
+  return configureFilters([]);
 };
 
 /**
@@ -59,8 +64,4 @@ const removeDuplicates = (tag: TagTypes, i: number, all: TagTypes[]): boolean =>
   return all.map((arr) => arr.name).indexOf(tag.name) === i;
 };
 
-/** Fetch a single career opportunity */
-export const getCareerOpportunity = async (id: number): Promise<ICareerOpportunity> => {
-  const data: ICareerOpportunity = await get(API_URL + id, { format: 'json', mode: 'no-cors' });
-  return data;
-};
+export const retrieveCareerOpportunity = retrieveResource<ICareerOpportunity>(API_URL);

--- a/src/career/containers/DetailView.tsx
+++ b/src/career/containers/DetailView.tsx
@@ -1,4 +1,4 @@
-import { getCareerOpportunity } from 'career/api';
+import { retrieveCareerOpportunity } from 'career/api';
 import { ICareerOpportunity } from 'career/models/Career';
 import { CareerContext } from 'career/providers/CareerProvider';
 import HttpError from 'core/components/errors/HttpError';
@@ -23,8 +23,10 @@ class DetailView extends Component<IProps, IState> {
   public async componentDidMount() {
     window.scrollTo(0, 0);
     const id = parseInt(this.props.match.params.id, 10);
-    const job = await getCareerOpportunity(id);
-    this.setState({ job });
+    const response = await retrieveCareerOpportunity(id);
+    if (response.status === 'success') {
+      this.setState({ job: response.data });
+    }
   }
 
   public render() {

--- a/src/common/resources/defaults.ts
+++ b/src/common/resources/defaults.ts
@@ -1,0 +1,8 @@
+export const HEADERS = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+};
+
+export const QUERY_PARAMETERS = {
+  format: 'json',
+};

--- a/src/common/resources/index.ts
+++ b/src/common/resources/index.ts
@@ -1,0 +1,85 @@
+import { IQueryObject, toQueryString } from '../utils/queryString';
+import { QUERY_PARAMETERS } from './defaults';
+import { IBaseListResourceQueryParams, IListResourceWrapper, ResponseType } from './types';
+import { buildUrl, getHeaders, handleReadOnlyResponse, handleResponse } from './utils';
+
+export const retrieveResource = <OutputData>(url: string, options?: RequestInit) => {
+  return async (id: number | string): Promise<ResponseType<never, OutputData>> => {
+    const response = await fetch(`${buildUrl(url)}${id}/`, {
+      method: 'GET',
+      headers: await getHeaders(),
+      ...options,
+    });
+
+    const data = await handleReadOnlyResponse<never, OutputData>(response);
+    return data;
+  };
+};
+
+export const listResource = <OutputData, QueryParams extends IQueryObject = {}>(url: string, options?: RequestInit) => {
+  type ResponseData = ResponseType<never, IListResourceWrapper<OutputData>>;
+  type AllQueryParams = QueryParams & IBaseListResourceQueryParams;
+  return async (queryParams?: AllQueryParams): Promise<ResponseData> => {
+    const queryString = toQueryString({
+      ...QUERY_PARAMETERS,
+      ...queryParams,
+    });
+
+    const response = await fetch(`${buildUrl(url)}${queryString}`, {
+      method: 'GET',
+      headers: await getHeaders(),
+      ...options,
+    });
+
+    const data = await handleReadOnlyResponse<never, IListResourceWrapper<OutputData>>(response);
+    return data;
+  };
+};
+
+export const createResource = <InputData, OutputData>(url: string, options?: RequestInit) => {
+  return async (inputData: InputData): Promise<ResponseType<InputData, OutputData>> => {
+    const response = await fetch(buildUrl(url), {
+      method: 'POST',
+      headers: await getHeaders(),
+      body: JSON.stringify(inputData),
+      ...options,
+    });
+
+    const data = await handleResponse<InputData, OutputData>(response);
+    return data;
+  };
+};
+
+export const updateResource = <InputData, OutputData>(url: string, options?: RequestInit) => {
+  return async (id: number | string, inputData: InputData): Promise<ResponseType<InputData, OutputData>> => {
+    const response = await fetch(`${buildUrl(url)}${id}/`, {
+      method: 'PUT',
+      headers: await getHeaders(),
+      body: JSON.stringify(inputData),
+      ...options,
+    });
+
+    const data = await handleResponse<InputData, OutputData>(response);
+    return data;
+  };
+};
+
+export const destroyResource = (url: string, options?: RequestInit) => {
+  return async (id: number | string): Promise<ResponseType<never, null>> => {
+    const response = await fetch(`${buildUrl(url)}${id}/`, {
+      method: 'DELETE',
+      headers: await getHeaders(),
+      ...options,
+    });
+
+    const data = await handleResponse<never, null>(response);
+    return data;
+  };
+};
+
+/**
+ * A partial update follows the same API as an update with the exception of taking a partial of the InputData and using the `PATCH` method instead of `PUT`.
+ */
+export const partialUpdateResource = <InputData, OutputData>([url, options, ...args]: Parameters<
+  typeof updateResource
+>) => updateResource<Partial<InputData>, OutputData>(url, { ...options, method: 'PATCH' }, ...args);

--- a/src/common/resources/types.ts
+++ b/src/common/resources/types.ts
@@ -1,0 +1,72 @@
+export type ResonseStatus = 'success' | 'error' | 'invalid';
+
+interface IResponse {
+  status: ResonseStatus;
+}
+
+/**
+ * A successful response should indicate 'success'.
+ * Just the expected data should be returned.
+ */
+interface ISuccessResponse<Output> extends IResponse {
+  status: 'success';
+  data: Output;
+}
+
+/**
+ * An error response should indicate 'error'.
+ * Error messages should only return the details of the error.
+ */
+interface IErrorResponse extends IResponse {
+  status: 'error';
+  errors: {
+    detail: string;
+  };
+}
+
+/**
+ * Django Rest Framework adds a spesific field for 'Bad request' responses with validation errors.
+ * This field is appended where the validation fails on something related to more than one field, or
+ * no single field at all.
+ */
+interface IErrorOutput {
+  non_field_errors?: string[];
+}
+
+/**
+ * Django Rest Framework will return an object that contains the invalid keys of an input object.
+ * The values for each key is an array of reasons for the field to be invalid.
+ * The `non_field_errors` field may contain errors whcih encompass more than a single field.
+ * @example
+ * 'POST' {username: 'olanordmann', name: 'Ola Nordmann', age: -10}
+ * // May return something like:
+ * {name: ['Username must be unique'], age: ['Age cannot be a negative number']}
+ */
+export type ErrorKeys<Output> = {
+  [K in keyof Output & IErrorOutput]?: string[];
+};
+
+/**
+ * An invalid response should indicate 'invalid'.
+ * Invalid response data includes the validation for each field of the input data.
+ * And possibly more data in form of `non_field_errors`.
+ */
+interface IInvalidResponse<Output> extends IResponse {
+  status: 'invalid';
+  errors: ErrorKeys<Output>;
+}
+
+export type ResponseType<Input, Output> = ISuccessResponse<Output> | IErrorResponse | IInvalidResponse<Input>;
+
+export interface IListResourceWrapper<OutputData> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: OutputData[];
+}
+
+export interface IBaseListResourceQueryParams {
+  page_size?: number;
+  page?: number;
+  format?: 'json' | string;
+}

--- a/src/common/resources/utils.ts
+++ b/src/common/resources/utils.ts
@@ -1,0 +1,75 @@
+import { getUser } from 'authentication/api';
+import { DOMAIN } from 'common/constants/endpoints';
+
+import { HEADERS } from './defaults';
+import { ResponseType } from './types';
+
+export const handleReadOnlyResponse = async <InputData, OutputData>(
+  response: Response
+): Promise<ResponseType<InputData, OutputData>> => {
+  if (response.ok) {
+    return {
+      status: 'success',
+      data: await response.json(),
+    };
+  } else {
+    return {
+      status: 'error',
+      errors: await response.json(),
+    };
+  }
+};
+
+export const handleResponse = async <InputData, OutputData>(
+  response: Response
+): Promise<ResponseType<InputData, OutputData>> => {
+  if (response.ok) {
+    if (response.status === 204) {
+      return {
+        status: 'success',
+        // Handle no-content responses as null.
+        // This is hind of dangerous, since null has to be defined as OutputData
+        // When the resouce is created.
+        // tslint:disable-next-line no-any
+        data: (null as any) as OutputData,
+      };
+    } else {
+      return {
+        status: 'success',
+        data: await response.json(),
+      };
+    }
+  } else if (response.status === 400) {
+    return {
+      status: 'invalid',
+      errors: await response.json(),
+    };
+  } else {
+    return {
+      status: 'error',
+      errors: await response.json(),
+    };
+  }
+};
+
+export const getHeaders = async () => {
+  try {
+    const user = await getUser();
+    if (user) {
+      return {
+        ...HEADERS,
+        Authorization: `Bearer ${user.access_token}`,
+      };
+    }
+    return HEADERS;
+  } catch {
+    return HEADERS;
+  }
+};
+
+const ABSOULTE_URL_REGEXP = new RegExp('^(?:[a-z]+:)?//', 'i');
+
+export const buildUrl = (url: string) => {
+  const baseUrl = ABSOULTE_URL_REGEXP.test(url) ? '' : `${DOMAIN}`;
+  return `${baseUrl}${url.startsWith('/') ? '' : '/'}${url}${url.endsWith('/') ? '' : '/'}`;
+};

--- a/src/contribution/api/repositories.tsx
+++ b/src/contribution/api/repositories.tsx
@@ -1,8 +1,5 @@
-import { get, IAPIData } from 'common/utils/api';
+import { listResource } from 'common/resources';
 
 import { IRepository } from 'contribution/models/Repository';
 
-export const getRepositories = async () => {
-  const data = await get<IAPIData<IRepository>>('/api/v1/repositories', { format: 'json' });
-  return data;
-};
+export const listRepositories = listResource<IRepository>('/api/v1/repositories');

--- a/src/contribution/components/RepositoryList.tsx
+++ b/src/contribution/components/RepositoryList.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { getRepositories } from '../api/repositories';
+import { listRepositories } from '../api/repositories';
 import Repository from '../components/Repository';
 import style from '../less/contribution.less';
 import { IRepository } from '../models/Repository';
@@ -12,8 +12,10 @@ export default class RepositoryList extends Component<{}, IRepositoryListState> 
   public readonly state: IRepositoryListState = { repositories: [] };
 
   public async componentDidMount() {
-    const data = await getRepositories();
-    this.setState({ repositories: data.results });
+    const response = await listRepositories({ page_size: 10 });
+    if (response.status === 'success') {
+      this.setState({ repositories: response.data.results });
+    }
   }
 
   public render() {


### PR DESCRIPTION
This PR experiments with making it easier to work with API-endpoints.

The way it is currently done can be both hard to understand and very error prone.

### _Why is this approach better?_
There are a few things that I think this does better than the old system:

- Endpoints for models are easier to create. Creating endpoints can be done based on what kind of action is used, you just input the required models for that action and a url. Example can be seen below. 
- Type-safety is is improved by **a lot**. It may look a little but cumbersome to handle the status of the response as seen below, but the result if that there is a lot harder to end up with errors.
- Support for Django Rest Framework built in. Completely typed response types and errors based on how DRF responds to different kinds of requests and errors.
- Probably more, but I'll come back to that later.

Other niceties that were either missing or broken with the old design:
- The user is always authenticated when sending a request if they are logged in. The previous design required configuration for each and every endpoint.
- Handles HTTP 204 no-content responses correctly (does not throw an error).

### Examples

Creating and endpoint for getting a single user can be done as such:
``` typescript
// Create the endpoint
const retrieveUser = retrieveResource<IUser>('/api/v1/users');

// Use the endpoint to fetch a user
const response = await retrieveUser(69);

// Handle is the request was successful
if (response.status === 'success') {
  // This user is typed to be of type `IUser`, never null or undefined
  const user = response.data
}
```

An endpoint for attending an event could look something like this:
``` typescript
// Create an interface describing the data that will be posted to the endpoint
interface ICreateAttendeeData {
  event: number;
  user: number;
}

// Create the endpoint for creating and Attendee
const createAttendee = createResource<ICreateAttendeeData, IAttendee>('/api/v1/registration/user-attendees');

const response = await createAttendee({ event: 666, user: 1337 });

if (response.status === 'success') {
  // If the response is a success we get an `IAttendee` object from the API.
  // This will never be null or undefined.
  const attendee = response.data;

} else if (response.status === 'invalid') {
  // If the response is invalid, it means that the validation on data we sent
  // in did not go through. The error object will then be correctly typed
  // with the errors that Django sends for the fields.
  const { errors } = response;

} else if (response.status === 'error') {
  // If any other type of error occurred during request, such as the user
  // not being authenticated, or the server not responding,
  // the request will respond with 'error'.
  // We then may get an error detail message for the server, or nothing.
  console.error(response.errors.detail);
}
```