### PR TITLE
Fix firefox frontpage bug for the event containers

### DIFF
--- a/src/events/components/ImageView/image.less
+++ b/src/events/components/ImageView/image.less
@@ -22,7 +22,7 @@
     grid-template-columns: 1fr 1fr 1fr;
   }
   .large {
-    max-height: 19rem;
+    max-height: 23rem;
   }
 }
 


### PR DESCRIPTION
Pretty weird bug at least for my firefox. Pretty much a very simple fix

Before on firefox:
![wtf](https://user-images.githubusercontent.com/41551253/68300129-7883f200-009d-11ea-950a-dbe83111806a.png)
After on firefox:
![wtf2](https://user-images.githubusercontent.com/41551253/68300132-7a4db580-009d-11ea-9e00-9eaa143e157d.png)
