### PR TITLE
Query API for event searches

### DIFF
--- a/src/common/components/Forms/SelectMultiple/index.tsx
+++ b/src/common/components/Forms/SelectMultiple/index.tsx
@@ -53,15 +53,22 @@ export interface ISelectable<T, K> {
 }
 
 export interface IProps<T, K> {
-  onChange: (value: ValueType<ISelectable<T, K>>) => void;
+  onChange: (value: Array<ISelectable<T, K>>) => void;
   selected: Array<ISelectable<T, K>>;
   selectOptions: Array<ISelectable<T, K>>;
   placeholder: string;
   getColor: (data: T) => string;
 }
 
-export function SelectMultiple<T, K>({ selected, selectOptions, getColor, ...props }: IProps<T, K>) {
+export function SelectMultiple<T, K>({ selected, selectOptions, getColor, onChange, ...props }: IProps<T, K>) {
   const optionStyles = getOptionStyles(getColor);
+  const handleChange = (value: ValueType<ISelectable<T, K>>) => {
+    if (value instanceof Array) {
+      onChange(value);
+    } else {
+      onChange([]);
+    }
+  };
   return (
     <Select<ISelectable<T, K>>
       options={selectOptions}
@@ -71,6 +78,7 @@ export function SelectMultiple<T, K>({ selected, selectOptions, getColor, ...pro
       components={makeAnimated()}
       closeMenuOnSelect={false}
       className={style.eventType}
+      onChange={handleChange}
       {...props}
     />
   );

--- a/src/common/utils/equality.ts
+++ b/src/common/utils/equality.ts
@@ -1,0 +1,9 @@
+type Comparator<T> = (val1: T, val2: T) => boolean;
+const DEFAULT_COMPARATOR = <T>(val1: T, val2: T): boolean => val1 === val2;
+
+export const isArrayEqual = <T>(comparator: Comparator<T> = DEFAULT_COMPARATOR) => (prev: T[], next: T[]) => {
+  if (prev.length !== next.length) {
+    return false;
+  }
+  return prev.every((value, index) => comparator(value, next[index]));
+};

--- a/src/events/api/events.ts
+++ b/src/events/api/events.ts
@@ -14,6 +14,7 @@ export interface IEventAPIParameters extends IQueryObject {
   is_attendee?: 'True' | 'False';
   query?: string;
   attendance_event__isnull?: 'True' | 'False';
+  ordering?: string;
 }
 
 const EVENTS_API_URL = '/api/v1/event/events/';

--- a/src/events/api/events.ts
+++ b/src/events/api/events.ts
@@ -1,28 +1,27 @@
 import { getUser } from 'authentication/api';
 import { IAuthUser } from 'authentication/models/User';
-import { get, getAllPages, IBaseAPIParameters } from 'common/utils/api';
+import { get, getAllPages, IBaseAPIParameters, IAPIData } from 'common/utils/api';
 import { EventTypeEnum, IAttendanceEvent, IEvent } from '../models/Event';
+import { listResource } from 'common/resources';
+import { IQueryObject } from 'common/utils/queryString';
 
-export interface IEventAPIParameters extends IBaseAPIParameters {
+export interface IEventAPIParameters extends IQueryObject {
   event_start__gte?: string;
   event_start__lte?: string;
   event_end__gte?: string;
   event_end__lte?: string;
   event_type?: EventTypeEnum[] | EventTypeEnum;
   is_attendee?: 'True' | 'False';
-}
-
-export interface IAPIData<T> {
-  results: T[];
-  next: string | null;
-  previous: string | null;
-  count: number;
+  query?: string;
+  attendance_event__isnull?: 'True' | 'False';
 }
 
 const EVENTS_API_URL = '/api/v1/event/events/';
 const ATTENDANCE_EVENT_API_URL = '/api/v1/event/attendance-events/';
 
-export const getEvents = async (args?: IEventAPIParameters): Promise<IEvent[]> => {
+export const listEvents = listResource<IEvent, IEventAPIParameters>(EVENTS_API_URL);
+
+export const getEvents = async (args?: IEventAPIParameters & IBaseAPIParameters): Promise<IEvent[]> => {
   const data = await get<IAPIData<IEvent>>(EVENTS_API_URL, { format: 'json', ...args });
   return data.results;
 };

--- a/src/events/components/Events.tsx
+++ b/src/events/components/Events.tsx
@@ -1,21 +1,18 @@
-import React, { useState } from 'react';
+import React, { FC } from 'react';
 
-import EventsHeader from './EventsHeader';
-import ListView from './ListView';
+import Heading from 'common/components/Heading';
+
 import SearchModule from './SearchModule';
+import { SearchResults } from './SearchModule/SearchResults';
 
 import style from './less/eventsContainer.less';
 
-const Events = () => {
-  const [accessible, setAccessible] = useState(false);
-
-  const toggleAccessible = () => setAccessible(!accessible);
-
+const Events: FC = () => {
   return (
     <section className={style.section}>
-      <EventsHeader toggleAccessible={toggleAccessible} accessible={accessible} />
+      <Heading title="Arrangementer" />
       <SearchModule />
-      <ListView accessible={accessible} filtered={true} />
+      <SearchResults />
     </section>
   );
 };

--- a/src/events/components/Events.tsx
+++ b/src/events/components/Events.tsx
@@ -4,6 +4,8 @@ import Heading from 'common/components/Heading';
 
 import SearchModule from './SearchModule';
 import { SearchResults } from './SearchModule/SearchResults';
+import { Stats } from './SearchModule/Stats';
+import { NextPageObserver } from './SearchModule/NextPageObserver';
 
 import style from './less/eventsContainer.less';
 
@@ -12,7 +14,9 @@ const Events: FC = () => {
     <section className={style.section}>
       <Heading title="Arrangementer" />
       <SearchModule />
+      <Stats />
       <SearchResults />
+      <NextPageObserver />
     </section>
   );
 };

--- a/src/events/components/EventsContainer.tsx
+++ b/src/events/components/EventsContainer.tsx
@@ -34,7 +34,7 @@ export const EventContainer = () => {
         accessible={accessible}
         view={eventView}
       />
-      <View accessible={accessible} filtered={false} />
+      <View accessible={accessible} />
     </section>
   );
 };

--- a/src/events/components/EventsContainer.tsx
+++ b/src/events/components/EventsContainer.tsx
@@ -24,17 +24,10 @@ export const EventContainer = () => {
   const [eventView, setEventView] = useState<EventView>(EventView.IMAGE);
   const View = getView(eventView);
 
-  const [accessible, setAccessible] = useState(false);
-  const toggleAccessible = () => setAccessible(!accessible);
   return (
     <section className={style.section}>
-      <EventsHeader
-        changeView={setEventView}
-        toggleAccessible={toggleAccessible}
-        accessible={accessible}
-        view={eventView}
-      />
-      <View accessible={accessible} />
+      <EventsHeader changeView={setEventView} view={eventView} />
+      <View />
     </section>
   );
 };

--- a/src/events/components/EventsHeader/index.tsx
+++ b/src/events/components/EventsHeader/index.tsx
@@ -1,20 +1,16 @@
 import React, { FC } from 'react';
 
-import ToggleSwitch from 'common/components/ToggleSwitch';
-
 import { EventView } from 'events/models/Event';
 import ChangeViewIconButton from './ChangeViewIconButton';
 
 import style from './eventsHeader.less';
 
 interface IProps {
-  toggleAccessible: () => void;
   changeView: (view: EventView) => void;
-  accessible: boolean;
   view: EventView;
 }
 
-const EventsHeader: FC<IProps> = ({ toggleAccessible, changeView, accessible, view }) => {
+const EventsHeader: FC<IProps> = ({ changeView, view }) => {
   return (
     <div className={style.grid}>
       <h1>Arrangementer</h1>
@@ -23,10 +19,6 @@ const EventsHeader: FC<IProps> = ({ toggleAccessible, changeView, accessible, vi
         <ChangeViewIconButton viewType={EventView.LIST} changeView={changeView} view={view} />
         <ChangeViewIconButton viewType={EventView.CALENDAR} changeView={changeView} view={view} />
       </div>
-      <span className={style.toggleAccessible}>
-        <span className={style.toggleAccessibleDescription}>Vis kun arrangementer du kan delta på</span>
-        <ToggleSwitch checked={accessible} onChange={toggleAccessible} />
-      </span>
     </div>
   );
 };

--- a/src/events/components/EventsHeader/index.tsx
+++ b/src/events/components/EventsHeader/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import ToggleSwitch from 'common/components/ToggleSwitch';
 
@@ -7,34 +7,28 @@ import ChangeViewIconButton from './ChangeViewIconButton';
 
 import style from './eventsHeader.less';
 
-export interface IProps {
+interface IProps {
   toggleAccessible: () => void;
-  changeView?: (view: EventView) => void;
+  changeView: (view: EventView) => void;
   accessible: boolean;
-  view?: EventView;
+  view: EventView;
 }
 
-const EventsHeader = ({ toggleAccessible, changeView, accessible, view }: IProps) => (
-  <div className={style.grid}>
-    <h1>Arrangementer</h1>
-    {changeView && view !== undefined ? (
+const EventsHeader: FC<IProps> = ({ toggleAccessible, changeView, accessible, view }) => {
+  return (
+    <div className={style.grid}>
+      <h1>Arrangementer</h1>
       <div className={style.choiceGrid}>
         <ChangeViewIconButton viewType={EventView.IMAGE} changeView={changeView} view={view} />
-
         <ChangeViewIconButton viewType={EventView.LIST} changeView={changeView} view={view} />
-
         <ChangeViewIconButton viewType={EventView.CALENDAR} changeView={changeView} view={view} />
       </div>
-    ) : null}
-
-    <span className={style.toggleAccessible}>
-      <span className={style.toggleAccessibleDescription}>
-        {!accessible ? 'Kan delta?' : 'Viser arrangementer du kan delta på'}
+      <span className={style.toggleAccessible}>
+        <span className={style.toggleAccessibleDescription}>Vis kun arrangementer du kan delta på</span>
+        <ToggleSwitch checked={accessible} onChange={toggleAccessible} />
       </span>
-
-      <ToggleSwitch checked={accessible} onChange={toggleAccessible} />
-    </span>
-  </div>
-);
+    </div>
+  );
+};
 
 export default EventsHeader;

--- a/src/events/components/ImageView/EventColumn.tsx
+++ b/src/events/components/ImageView/EventColumn.tsx
@@ -1,27 +1,28 @@
-import React from 'react';
+import React, { FC } from 'react';
 
-import { IEvent } from 'events/models/Event';
 import { EventTypeEnum } from '../../models/Event';
 import style from './image.less';
 import LargeEvent from './LargeEvent';
 import LargeEventPlaceholder from './LargeEventPlaceholder';
-import SmallEventColumn from './SmallEvent';
+import SmallEvent from './SmallEvent';
 
-export interface IProps {
-  events: IEvent[];
-  event_type: EventTypeEnum;
+interface IProps {
+  eventIds: number[];
+  eventType: EventTypeEnum;
 }
 
-const EventColumn = ({ events, event_type }: IProps) => {
+const EventColumn: FC<IProps> = ({ eventIds, eventType }: IProps) => {
   return (
     <div className={style.eventColumn}>
-      {events[0] ? (
+      {eventIds[0] ? (
         <>
-          <LargeEvent event={events[0]} />
-          <SmallEventColumn events={events.slice(1, 4)} />
+          <LargeEvent eventId={eventIds[0]} />
+          {eventIds.slice(1, 4).map((eventId) => (
+            <SmallEvent key={eventId} eventId={eventId} />
+          ))}
         </>
       ) : (
-        <LargeEventPlaceholder event_type={event_type} />
+        <LargeEventPlaceholder eventType={eventType} />
       )}
     </div>
   );

--- a/src/events/components/ImageView/LargeEvent.tsx
+++ b/src/events/components/ImageView/LargeEvent.tsx
@@ -11,12 +11,14 @@ import { selectEventCapacity } from 'events/selectors/event';
 
 import EventImage from '../EventImage';
 import style from './image.less';
+import { eventSelectors } from 'events/slices/events';
 
-export interface IProps {
-  event: IEvent;
+interface IProps {
+  eventId: number;
 }
 
-const LargeEvent: FC<IProps> = ({ event }) => {
+const LargeEvent: FC<IProps> = ({ eventId }) => {
+  const event = useSelector((state) => eventSelectors.selectById(state, eventId) as IEvent);
   const { images, event_type, event_type_display, title, start_date, id } = event;
   const capacity = useSelector(selectEventCapacity(id));
   const color = getEventColor(event_type);

--- a/src/events/components/ImageView/LargeEventPlaceholder.tsx
+++ b/src/events/components/ImageView/LargeEventPlaceholder.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 
-import { getEventColor, getEventType } from 'events/models/Event';
+import { getEventColor, getEventType, EventTypeEnum } from 'events/models/Event';
 
 import { DefaultEventImage } from '../DefaultEventImage';
 import style from './image.less';
 
 interface IProps {
-  event_type: number;
+  eventType: EventTypeEnum;
 }
 
-const LargeEventPlaceholder = ({ event_type }: IProps) => {
-  const eventTypeName = getEventType(event_type);
+const LargeEventPlaceholder = ({ eventType }: IProps) => {
+  const eventTypeName = getEventType(eventType);
   return (
     <>
       <div className={style.large}>
-        <h2 className={style.imageLargeType} style={{ background: getEventColor(event_type) }}>
+        <h2 className={style.imageLargeType} style={{ background: getEventColor(eventType) }}>
           {eventTypeName}
         </h2>
-        <DefaultEventImage color={getEventColor(event_type)} />
+        <DefaultEventImage color={getEventColor(eventType)} />
         <div className={style.largeContentEmpty}>
           <p>Vi er tom for arrangementer av typen {eventTypeName}</p>
         </div>

--- a/src/events/components/ImageView/SmallEvent.tsx
+++ b/src/events/components/ImageView/SmallEvent.tsx
@@ -8,14 +8,16 @@ import { Link } from 'core/components/Router';
 import { useSelector } from 'core/redux/hooks';
 import { getEventColor, IEvent } from 'events/models/Event';
 import { selectEventCapacity } from 'events/selectors/event';
+import { eventSelectors } from 'events/slices/events';
 
 import style from './image.less';
 
 interface IProps {
-  event: IEvent;
+  eventId: number;
 }
 
-const SmallEvent: FC<IProps> = ({ event }) => {
+export const SmallEvent: FC<IProps> = ({ eventId }) => {
+  const event = useSelector((state) => eventSelectors.selectById(state, eventId) as IEvent);
   const capacity = useSelector(selectEventCapacity(event.id));
   return (
     <Link {...getEventUrl(event.id)}>
@@ -37,14 +39,4 @@ const SmallEvent: FC<IProps> = ({ event }) => {
   );
 };
 
-const SmallEventColumn = ({ events }: { events: IEvent[] }) => {
-  return (
-    <>
-      {events.map((event) => (
-        <SmallEvent key={event.id} event={event} />
-      ))}
-    </>
-  );
-};
-
-export default SmallEventColumn;
+export default SmallEvent;

--- a/src/events/components/ListView/EventList.tsx
+++ b/src/events/components/ListView/EventList.tsx
@@ -16,7 +16,6 @@ interface IProps {
 
 const EventListComponent: FC<IProps> = ({ eventIds }) => {
   const events = useSelector(selectEventsByIds(eventIds), shallowEqual);
-  console.log('rendering list');
 
   return (
     <div className={style.grid}>

--- a/src/events/components/ListView/EventList.tsx
+++ b/src/events/components/ListView/EventList.tsx
@@ -1,0 +1,40 @@
+import React, { FC } from 'react';
+
+import { getEventUrl } from 'core/appUrls';
+import { Link } from 'core/components/Router';
+
+import { useSelector } from 'core/redux/hooks';
+import { eventSelectors } from 'events/slices/events';
+import style from './list.less';
+import ListEvent from './ListEvent';
+import { State } from 'core/redux/Store';
+import { shallowEqual } from 'react-redux';
+
+interface IProps {
+  eventIds: number[];
+}
+
+const EventListComponent: FC<IProps> = ({ eventIds }) => {
+  const events = useSelector(selectEventsByIds(eventIds), shallowEqual);
+  console.log('rendering list');
+
+  return (
+    <div className={style.grid}>
+      {events.map((event) => (
+        <Link {...getEventUrl(event.id)} key={event.id}>
+          <a>
+            <ListEvent event={event} />
+          </a>
+        </Link>
+      ))}
+    </div>
+  );
+};
+
+const selectEventsByIds = (eventIds: number[]) => (state: State) => {
+  return eventSelectors.selectAll(state).filter((event) => eventIds.some((eventId) => event.id === eventId));
+};
+
+const isEventListEqual = (prevProps: IProps, nextProps: IProps) => shallowEqual(prevProps.eventIds, nextProps.eventIds);
+
+export const EventList = React.memo(EventListComponent, isEventListEqual);

--- a/src/events/components/SearchModule/NextPageObserver.less
+++ b/src/events/components/SearchModule/NextPageObserver.less
@@ -1,0 +1,5 @@
+.infoText {
+  width: 100%;
+  text-align: center;
+  margin: 16px 0;
+}

--- a/src/events/components/SearchModule/NextPageObserver.tsx
+++ b/src/events/components/SearchModule/NextPageObserver.tsx
@@ -1,20 +1,47 @@
 import React, { FC, useEffect, useState } from 'react';
 
 import { useIntersection } from 'common/hooks/useIntersection';
-import { useDispatch } from 'core/redux/hooks';
+import { useDispatch, useSelector } from 'core/redux/hooks';
+import { State } from 'core/redux/Store';
 import { nextEventPage } from 'events/slices/events';
+
+import style from './NextPageObserver.less';
 
 export const NextPageObserver: FC = () => {
   const dispatch = useDispatch();
+  const isPending = useSelector(selectIsSearchPending());
+  const totalCount = useSelector(selectTotalCount());
+  const currentCount = useSelector(selectCurrentCount());
   const [observer, ref] = useIntersection();
-  const [count, setCount] = useState(0); // TODO: Implement inside useIntersection somehow.
+  const [renderCount, setRenderCount] = useState(0); // TODO: Implement inside useIntersection somehow.
+
+  const isSeachCompleted = totalCount === currentCount;
 
   useEffect(() => {
-    if (observer && observer.isIntersecting && count !== 0) {
+    if (observer && observer.isIntersecting && renderCount !== 0 && !isSeachCompleted && !isPending) {
       dispatch(nextEventPage());
     }
     // TODO: Figure out why this is needed, and implement it inside the hook.
-    setCount((stateCount) => stateCount + 1);
-  }, [observer, dispatch]);
-  return <span ref={ref}></span>;
+    setRenderCount((current) => current + 1);
+  }, [dispatch, observer, isSeachCompleted, isPending]);
+
+  return (
+    <>
+      <p className={style.infoText}>{`Viser ${currentCount} av ${totalCount} resultater for dette søket`}</p>
+      <p className={style.infoText}>{isPending && 'Henter flere resultater...'}</p>
+      <span ref={ref}></span>
+    </>
+  );
+};
+
+const selectIsSearchPending = () => (state: State) => {
+  return state.events.search.loading === 'pending';
+};
+
+const selectTotalCount = () => (state: State) => {
+  return state.events.search.count;
+};
+
+const selectCurrentCount = () => (state: State) => {
+  return state.events.search.ids.length;
 };

--- a/src/events/components/SearchModule/NextPageObserver.tsx
+++ b/src/events/components/SearchModule/NextPageObserver.tsx
@@ -1,0 +1,20 @@
+import React, { FC, useEffect, useState } from 'react';
+
+import { useIntersection } from 'common/hooks/useIntersection';
+import { useDispatch } from 'core/redux/hooks';
+import { nextEventPage } from 'events/slices/events';
+
+export const NextPageObserver: FC = () => {
+  const dispatch = useDispatch();
+  const [observer, ref] = useIntersection();
+  const [count, setCount] = useState(0); // TODO: Implement inside useIntersection somehow.
+
+  useEffect(() => {
+    if (observer && observer.isIntersecting && count !== 0) {
+      dispatch(nextEventPage());
+    }
+    // TODO: Figure out why this is needed, and implement it inside the hook.
+    setCount((stateCount) => stateCount + 1);
+  }, [observer, dispatch]);
+  return <span ref={ref}></span>;
+};

--- a/src/events/components/SearchModule/NextPageObserver.tsx
+++ b/src/events/components/SearchModule/NextPageObserver.tsx
@@ -15,15 +15,15 @@ export const NextPageObserver: FC = () => {
   const [observer, ref] = useIntersection();
   const [renderCount, setRenderCount] = useState(0); // TODO: Implement inside useIntersection somehow.
 
-  const isSeachCompleted = totalCount === currentCount;
+  const isSearchCompleted = totalCount === currentCount;
 
   useEffect(() => {
-    if (observer && observer.isIntersecting && renderCount !== 0 && !isSeachCompleted && !isPending) {
+    if (observer && observer.isIntersecting && renderCount !== 0 && !isSearchCompleted && !isPending) {
       dispatch(nextEventPage());
     }
     // TODO: Figure out why this is needed, and implement it inside the hook.
     setRenderCount((current) => current + 1);
-  }, [dispatch, observer, isSeachCompleted, isPending]);
+  }, [dispatch, observer, isSearchCompleted, isPending]);
 
   return (
     <>

--- a/src/events/components/SearchModule/SearchResults.tsx
+++ b/src/events/components/SearchModule/SearchResults.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from 'react';
+
+import { useSelector } from 'core/redux/hooks';
+import { State } from 'core/redux/Store';
+
+import { EventList } from '../ListView/EventList';
+import { eventSelectors } from 'events/slices/events';
+import { isArrayEqual } from 'common/utils/equality';
+
+export const SearchResults: FC = () => {
+  const eventIds = useSelector(selectSearchResultEventIds(), isArrayEqual());
+  const isPending = useSelector(selectIsSearchPending());
+  const count = useSelector(selectSearchCount());
+  return (
+    <>
+      <div>
+        <p>Antall resultater: {count}</p>
+        <p>{isPending && 'Søker...'}</p>
+      </div>
+      <EventList eventIds={eventIds} />
+    </>
+  );
+};
+
+const selectSearchResultEventIds = () => (state: State) => {
+  const resultIds = state.events.search.ids;
+  return eventSelectors
+    .selectIds(state)
+    .map(Number)
+    .filter((eventId) => resultIds.some((resultId) => resultId === eventId));
+};
+
+const selectIsSearchPending = () => (state: State) => {
+  return state.events.search.loading === 'pending';
+};
+
+const selectSearchCount = () => (state: State) => {
+  return state.events.search.count;
+};

--- a/src/events/components/SearchModule/SearchResults.tsx
+++ b/src/events/components/SearchModule/SearchResults.tsx
@@ -9,17 +9,7 @@ import { isArrayEqual } from 'common/utils/equality';
 
 export const SearchResults: FC = () => {
   const eventIds = useSelector(selectSearchResultEventIds(), isArrayEqual());
-  const isPending = useSelector(selectIsSearchPending());
-  const count = useSelector(selectSearchCount());
-  return (
-    <>
-      <div>
-        <p>Antall resultater: {count}</p>
-        <p>{isPending && 'Søker...'}</p>
-      </div>
-      <EventList eventIds={eventIds} />
-    </>
-  );
+  return <EventList eventIds={eventIds} />;
 };
 
 const selectSearchResultEventIds = () => (state: State) => {
@@ -28,12 +18,4 @@ const selectSearchResultEventIds = () => (state: State) => {
     .selectIds(state)
     .map(Number)
     .filter((eventId) => resultIds.some((resultId) => resultId === eventId));
-};
-
-const selectIsSearchPending = () => (state: State) => {
-  return state.events.search.loading === 'pending';
-};
-
-const selectSearchCount = () => (state: State) => {
-  return state.events.search.count;
 };

--- a/src/events/components/SearchModule/SelectEventTypes.tsx
+++ b/src/events/components/SearchModule/SelectEventTypes.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { ValueType } from 'react-select/src/types';
 
-import { ISelectable, SelectMultiple } from 'common/components/Forms/SelectMultiple';
+import { SelectMultiple, ISelectable } from 'common/components/Forms/SelectMultiple';
 import { DEFAULT_EVENT_TYPES_PARAM } from 'core/hooks/useQueryParamsState';
 import { EventType, EventTypeEnum, getEventColor, getEventType } from 'events/models/Event';
 
@@ -12,10 +12,21 @@ const options = JSON.parse(DEFAULT_EVENT_TYPES_PARAM).map((eventType: EventTypeE
 
 export interface IProps {
   selected: EventTypeEnum[];
-  onChange: (value: ValueType<ISelectable<EventTypeEnum, EventType>>) => void;
+  onChange: (value: EventTypeEnum[]) => void;
 }
 
 export const SelectEventTypes: FC<IProps> = ({ selected = [], onChange }) => {
+  const handleChange = (value: ValueType<ISelectable<EventTypeEnum, EventType>>) => {
+    if (value !== null) {
+      const actualValue = value as Array<ISelectable<EventTypeEnum, EventType>>;
+      const newEventTypes = actualValue.map((e) => e.value);
+      if (newEventTypes.length > 0) {
+        onChange(newEventTypes);
+      } else {
+        onChange([]);
+      }
+    }
+  };
   const selectedItems = selected.map((eventType) => ({
     value: eventType,
     label: getEventType(eventType),
@@ -26,7 +37,7 @@ export const SelectEventTypes: FC<IProps> = ({ selected = [], onChange }) => {
       selectOptions={options}
       selected={selectedItems}
       getColor={(type) => getEventColor(type)}
-      onChange={onChange}
+      onChange={handleChange}
     />
   );
 };

--- a/src/events/components/SearchModule/Stats.less
+++ b/src/events/components/SearchModule/Stats.less
@@ -1,0 +1,6 @@
+.container {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin: 16px 0;
+}

--- a/src/events/components/SearchModule/Stats.tsx
+++ b/src/events/components/SearchModule/Stats.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+
+import { useSelector } from 'core/redux/hooks';
+import { State } from 'core/redux/Store';
+
+import style from './Stats.less';
+
+export const Stats: FC = () => {
+  const isPending = useSelector(selectIsSearchPending());
+  const count = useSelector(selectSearchCount());
+  return (
+    <div className={style.container}>
+      <p>{isPending && 'Søker...'}</p>
+      <p>Antall resultater: {count}</p>
+    </div>
+  );
+};
+
+const selectIsSearchPending = () => (state: State) => {
+  return state.events.search.loading === 'pending';
+};
+
+const selectSearchCount = () => (state: State) => {
+  return state.events.search.count;
+};

--- a/src/events/components/SearchModule/index.tsx
+++ b/src/events/components/SearchModule/index.tsx
@@ -1,38 +1,53 @@
 import React, { FC, useState, useEffect } from 'react';
 
 import { SearchInput } from 'common/components/Forms/SearchInput';
-import ToggleSwitch from 'common/components/ToggleSwitch';
-import { useDispatch } from 'core/redux/hooks';
+import { useDispatch, useSelector } from 'core/redux/hooks';
+import { State } from 'core/redux/Store';
 import { EventTypeEnum } from 'events/models/Event';
+import { filterEvents, AttendanceFilterType, ATTENDANCE_FILTERS, resetEventPage } from 'events/slices/events';
 
 import style from './search.less';
 import { SelectEventTypes } from './SelectEventTypes';
-import { filterEvents } from 'events/slices/events';
+import { NextPageObserver } from './NextPageObserver';
 
 const SearchModule: FC = () => {
   const dispatch = useDispatch();
+  const page = useSelector(selectCurrentPage());
   const [query, setQuery] = useState('');
   const [eventTypes, setEventTypes] = useState<EventTypeEnum[]>([]);
-  const [showOnlyAttendanceEvents, setShowOnlyAttendanceEvents] = useState(false);
-
-  const toggleShowOnlyAttendanceEvents = () => {
-    setShowOnlyAttendanceEvents((current) => !current);
-  };
+  const [attendanceFilter, setAttendanceFilter] = useState<AttendanceFilterType>('SHOW_ALL');
 
   useEffect(() => {
-    dispatch(filterEvents({ query, eventTypes, showOnlyAttendanceEvents }));
-  }, [query, showOnlyAttendanceEvents, String(eventTypes)]);
+    dispatch(filterEvents({ query, eventTypes, attendanceFilter, page }));
+  }, [query, String(eventTypes), attendanceFilter, page]);
+
+  useEffect(() => {
+    dispatch(resetEventPage());
+  }, [query, String(eventTypes), attendanceFilter]);
 
   return (
-    <div className={style.grid}>
+    <div className={style.container}>
       <SearchInput defaultValue={query} onChange={(event) => setQuery(event.target.value)} />
-      <label className={style.attendanceEvent}>
-        <span>Vis kun arrangementer med påmelding</span>
-        <ToggleSwitch onChange={toggleShowOnlyAttendanceEvents} checked={showOnlyAttendanceEvents} />
-      </label>
-      <SelectEventTypes selected={eventTypes} onChange={setEventTypes} />
+      <div className={style.grid}>
+        <SelectEventTypes selected={eventTypes} onChange={setEventTypes} />
+        <select
+          onChange={(event) => setAttendanceFilter(event.target.value as AttendanceFilterType)}
+          value={attendanceFilter}
+        >
+          {Object.entries(ATTENDANCE_FILTERS).map(([value, description]) => (
+            <option key={value} value={value}>
+              {description}
+            </option>
+          ))}
+        </select>
+      </div>
+      <NextPageObserver />
     </div>
   );
+};
+
+const selectCurrentPage = () => (state: State) => {
+  return state.events.search.page;
 };
 
 export default SearchModule;

--- a/src/events/components/SearchModule/index.tsx
+++ b/src/events/components/SearchModule/index.tsx
@@ -8,7 +8,6 @@ import { filterEvents, AttendanceFilterType, ATTENDANCE_FILTERS, resetEventPage 
 
 import style from './search.less';
 import { SelectEventTypes } from './SelectEventTypes';
-import { NextPageObserver } from './NextPageObserver';
 
 const SearchModule: FC = () => {
   const dispatch = useDispatch();
@@ -41,7 +40,6 @@ const SearchModule: FC = () => {
           ))}
         </select>
       </div>
-      <NextPageObserver />
     </div>
   );
 };

--- a/src/events/components/SearchModule/search.less
+++ b/src/events/components/SearchModule/search.less
@@ -2,11 +2,18 @@
 @import '~common/less/constants.less';
 @import '~common/less/colors.less';
 
+@gap: 20px;
+
+.container {
+  display: grid;
+  gap: @gap;
+}
+
 .grid {
   display: grid;
   align-items: end;
   grid-template-columns: 1.618fr minmax(328px, 1fr);
-  grid-gap: 20px;
+  gap: @gap;
   width: 100%;
 
   @media screen and (max-width: @owMobileBreakpoint) {
@@ -17,17 +24,4 @@
       margin: auto;
     }
   }
-}
-
-.attendanceEvent {
-  text-align: right;
-  margin: auto 0;
-
-  > span {
-    margin-right: 10px;
-  }
-}
-
-.dateInput {
-  float: right;
 }

--- a/src/events/models/Event.ts
+++ b/src/events/models/Event.ts
@@ -1,10 +1,6 @@
 import { IUserName } from 'authentication/models/User';
 import IResponsiveImage from 'common/models/ResponsiveImage';
 
-export interface IEventViewProps {
-  accessible: boolean;
-}
-
 export enum EventTypeEnum {
   NONE,
   SOSIALT,

--- a/src/events/slices/events.ts
+++ b/src/events/slices/events.ts
@@ -6,7 +6,7 @@ import { DateTime, Interval } from 'luxon';
 
 const eventsAdapter = createEntityAdapter<IEvent>({
   sortComparer: (eventA, eventB) => {
-    return Number(DateTime.fromISO(eventA.start_date) > DateTime.fromISO(eventB.start_date));
+    return eventB.start_date.localeCompare(eventA.start_date);
   },
 });
 
@@ -91,6 +91,7 @@ export const filterEvents = createAsyncThunk('events/fitler', async (filters: Ev
       event_type: filters.eventTypes,
       page_size: pageSize,
       page,
+      ordering: '-event_start',
     })
   );
   return unwrapResult(response);

--- a/src/events/slices/events.ts
+++ b/src/events/slices/events.ts
@@ -30,7 +30,7 @@ export const fetchEventList = createAsyncThunk('events/fetchList', async (_, { d
   const response = await dispatch(
     fetchEvents({
       event_end__gte: DateTime.local().toISODate(),
-      page_size: 10,
+      page_size: 20,
     })
   );
   return unwrapResult(response);


### PR DESCRIPTION
Uses the events-api for searching events instead of doing it front-end. Gives indexed search based on Watson, and is overall more pleasant and responsive to use.

Resolves #236 
Resolves #363 