### PR TITLE
Remove color effect on HSP hover

### DIFF
--- a/src/core/components/Footer/footer.less
+++ b/src/core/components/Footer/footer.less
@@ -64,7 +64,3 @@
 .social:not(:last-child) {
   margin-right: 5px;
 }
-
-.sponsor:hover {
-  filter: brightness(0.35) sepia(1) hue-rotate(124deg) saturate(500%);
-}


### PR DESCRIPTION
Your current HSP has a black-white color scheme, which fits with the current footer's standard hover. 
The CSS for the special hover effect can thus be removed without any further additions.
Resolves #347 