### PR TITLE
Configure browserslist a bit better

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "@types/react": "^16.8.1"
   },
   "browserslist": [
-    "last 2 versions",
-    "> 5% in NO"
+    "> 1% in NO",
+    "not ie 11",
+    "not op_mini all"
   ]
 }


### PR DESCRIPTION
This change will give us a browserslist something like this:

Resolves #184 by as commented in #151 and written about here: https://jamie.build/last-2-versions

```
and_chr 80
chrome 80
chrome 79
edge 18
firefox 74
ios_saf 13.3
ios_saf 13.0-13.1
ios_saf 12.2-12.4
safari 13
samsung 11.1
```

as compared to our previous version:

```
and_chr 80
and_ff 68
and_qq 1.2
and_uc 12.12
android 80
baidu 7.12
bb 10
bb 7
chrome 81
chrome 80
edge 80
edge 79
firefox 75
firefox 74
ie 11
ie 10
ie_mob 11
ie_mob 10
ios_saf 13.3
ios_saf 13.2
kaios 2.5
op_mini all
op_mob 46
op_mob 12.1
opera 67
opera 66
safari 13
safari 12.1
samsung 11.1
samsung 10.1
```