### PR TITLE
Fix comment issue in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Describe the bug**  
-<!--A clear and concise description of what the bug is.->
+<!--A clear and concise description of what the bug is.-->
 
 **To Reproduce**
 Steps to reproduce the behavior:


### PR DESCRIPTION
A missing hyphen commented out more content than intended since the closing tag was not understood.