### PR TITLE
Fix oidc app failing to fetch clients in app connections

### DIFF
--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -37,8 +37,12 @@ const performRequest = async (query: string, parameters: IQueryObject = {}, opti
   }
   const headers = {
     ...options.headers,
-    Authorization: options.user ? `Bearer ${options.user.access_token}` : '',
-  };
+  } as Record<string, string>;
+
+  if (options.user) {
+    headers['Authorization'] = `Bearer ${options.user.access_token}`;
+  }
+
   const requestOptions = { ...restOptions, headers };
   const response = await fetch(url, requestOptions);
   if (response.status === 204) {

--- a/src/oidc_clients/api/clients.ts
+++ b/src/oidc_clients/api/clients.ts
@@ -11,7 +11,7 @@ type ClientResponseType = { response_types: number[] } & Omit<IOidcClient, 'resp
 // fetches specific client
 export const getClient = async (id: number): Promise<IOidcClient> => {
   try {
-    const client = await get<ClientResponseType>(API_BASE + 'clients/' + id);
+    const client = await get<ClientResponseType>(API_BASE + 'clients/' + id + '/');
     const responseTypes = await getResponseTypes();
     const newResponseTypes = client.response_types.flatMap((response_type) => {
       const responseType = responseTypes.get(response_type);


### PR DESCRIPTION
 - Add '/' to end of client request to prevent redirect
 - Remove Authorization header if no user is supplied to performRequest