### PR TITLE
change to network then cache

### DIFF
--- a/public/serviceworker.js
+++ b/public/serviceworker.js
@@ -7,7 +7,7 @@ sw.addEventListener('install', () => {
 });
 
 // Cleanup unwanted caches
-self.addEventListener('activate', (event) => {
+sw.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((cacheNames) => {
       return Promise.all(

--- a/public/serviceworker.js
+++ b/public/serviceworker.js
@@ -3,7 +3,7 @@ const cacheName = 'owf-cache';
 const cachesToKeep = [cacheName];
 
 sw.addEventListener('install', () => {
-  self.skipWaiting(); // Ensures that any new, waiting eventlistener becomes the active one.
+  sw.skipWaiting(); // Ensures that any new, waiting eventlistener becomes the active one.
 });
 
 // Cleanup unwanted caches
@@ -41,12 +41,12 @@ const networkThenCache = (event) => {
 
 const displayNotification = async (event) => {
   /** Cancel if notifications are not supported or not granted access */
-  if (!(self.Notification && self.Notification.permission === 'granted')) {
+  if (!(sw.Notification && sw.Notification.permission === 'granted')) {
     return;
   }
 
   const { title, ...noti } = event.data.json();
-  await self.registration.showNotification(title, noti);
+  await sw.registration.showNotification(title, noti);
 
   return;
 };


### PR DESCRIPTION
This PR makes some changes to our serviceworker and the caching strategies outlined in it. 

If this is merged we will be using a network-then-cache strategy. Which means that when a fetch is made we send that request of to the server. The response is copied and used both to update the cache and served to the user. Cache is only used as a fallback in case of no network. 

This is slower then a cache first strategy, where you reply with the response from cache right away. However this also ensures that the user get the most recent data, while ensuring partial functionality while offline. 

We could employ a much more complex caching strategy. Precaching certain routes on install or using different approaches for the different kinds of information we provide, but this is a reasonable first step. 

These two links are excellent resources for understanding the potential: 
https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/
https://developers.google.com/web/fundamentals/primers/service-workers

However there is also a definite question to be asked surrounding return on investment. At the moment I don't think any of the potential changes we can make are critical, and as such I suggest letting this rest unless someone is very motivated to learn about offline-first. 
