### PR TITLE
Calendar today CSS

### DIFF
--- a/src/events/components/CalendarView/CalendarTile.less
+++ b/src/events/components/CalendarView/CalendarTile.less
@@ -23,11 +23,9 @@
   box-shadow: none;
 }
 .tileToday {
-  display: block;
+  display: inline-block;
   text-align: center;
   padding: 3px;
-  width: 1rem;
-  height: 1rem;
   color: @offWhite;
   background-color: @darkBlue;
   border-radius: 50%;


### PR DESCRIPTION
Make today span inline block, to better fit background color and have same height as other views

## Old

[
<img width="227" alt="Screenshot 2020-09-14 at 21 15 20" src="https://user-images.githubusercontent.com/22390745/93128569-f9554680-f6cf-11ea-9326-bc40bb604108.png">
](url)

## New

<img width="244" alt="Screenshot 2020-09-14 at 21 15 29" src="https://user-images.githubusercontent.com/22390745/93128586-fe19fa80-f6cf-11ea-840e-9fc86a149913.png">
