### PR TITLE
Remove trailing slash from redirect url

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,7 @@ const redirects = async () => {
       permanent: true,
     },
     {
-      source: '/careeropportunity/:careerId/',
+      source: '/careeropportunity/:careerId',
       destination: '/career/:careerId',
       permanent: true,
     },


### PR DESCRIPTION
redirect url doesnt work with trailing slash