### PR TITLE
Display date and attendees non-stacked on small screens

### DIFF
--- a/src/events/components/ListView/list.less
+++ b/src/events/components/ListView/list.less
@@ -70,7 +70,15 @@
 
 @media (max-width: @owMobileBreakpoint) {
   .gridRow {
-    grid-template-columns: 5fr 1.5rem 3rem 1.5rem 3.5rem;
+    grid-template-columns: 3fr 0.5fr 1fr;
+    grid-template-rows: 1fr auto;
+
+    & > p:first-of-type {
+      grid-row: 1 / span 2;
+    }
+  }
+  .icon {
+    grid-column-start: 2;
   }
   .eventTypeDiv,
   .eventType {


### PR DESCRIPTION
Resolves #419 
![](http://folk.ntnu.no/johannkv/img/firefox_36oiAg44BO.png)

Will result in some spacing between the number-based information on long titles, but atleast it won't overlap!
(I'll gladly accept suggestions on how to make the number-based information stay together no matter the size)