### PR TITLE
fix sortOrder in listView

### DIFF
--- a/src/events/components/ListView/EventList.tsx
+++ b/src/events/components/ListView/EventList.tsx
@@ -12,11 +12,14 @@ import { shallowEqual } from 'react-redux';
 
 interface IProps {
   eventIds: number[];
+  sortOrder?: 'ASC' | 'DESC';
 }
 
-const EventListComponent: FC<IProps> = ({ eventIds }) => {
+const EventListComponent: FC<IProps> = ({ eventIds, sortOrder = 'ASC' }) => {
   const events = useSelector(selectEventsByIds(eventIds), shallowEqual);
-
+  if (sortOrder == 'DESC') {
+    events.reverse();
+  }
   return (
     <div className={style.grid}>
       {events.map((event) => (

--- a/src/events/components/ListView/index.tsx
+++ b/src/events/components/ListView/index.tsx
@@ -16,7 +16,7 @@ export const ListView: FC = () => {
     dispatch(fetchEventList());
   }, []);
 
-  return <EventList eventIds={eventIds} />;
+  return <EventList eventIds={eventIds} sortOrder="DESC" />;
 };
 
 const selectFutureEventIds = () => (state: State) => {


### PR DESCRIPTION
Added a prop in EventListComponent, such that you can decide the the order you want to sort the events in. The default value is descending, so the frontpage will have the correct sorting by default.

![image](https://user-images.githubusercontent.com/35420892/93712319-701d9400-fb55-11ea-888f-fb57b586cd62.png)


