### PR TITLE
Hide toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "3.8.3"
   },
   "dependencies": {
-    "@dotkomonline/design-system": "^0.17.0",
+    "@dotkomonline/design-system": "^0.18.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-brands-svg-icons": "^5.8.2",
     "@fortawesome/free-regular-svg-icons": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "3.8.3"
   },
   "dependencies": {
-    "@dotkomonline/design-system": "^0.16.0",
+    "@dotkomonline/design-system": "^0.17.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-brands-svg-icons": "^5.8.2",
     "@fortawesome/free-regular-svg-icons": "^5.7.2",

--- a/src/frontpage/components/ToastOld/index.tsx
+++ b/src/frontpage/components/ToastOld/index.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck;
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useToast } from 'core/utils/toast/useToast';
 import { Checkbox } from '@dotkomonline/design-system';
 

--- a/src/frontpage/components/ToastOld/index.tsx
+++ b/src/frontpage/components/ToastOld/index.tsx
@@ -3,10 +3,14 @@ import React, { useEffect, useState } from 'react';
 import { useToast } from 'core/utils/toast/useToast';
 import { Checkbox } from '@dotkomonline/design-system';
 
+
 const SHOW_TOAST = 'showOldOWToast';
 
 const Message: React.FC = () => {
-  const saveDoNotShow = (isChecked?: boolean) => window.localStorage.setItem(SHOW_TOAST, isChecked ? 'true' : 'false');
+  const saveDoNotShow = (isChecked?: boolean) => {
+    console.log(isChecked);
+    window.localStorage.setItem(SHOW_TOAST, isChecked ? 'true' : 'false');
+  };
 
   return (
     <div>
@@ -19,7 +23,7 @@ const Message: React.FC = () => {
         Oppdager du noen feil, mangler, eller ønsker, send mail til dotkom@online.ntnu.no eller lag et issue på{' '}
         <a href="https://github.com/dotkom/onlineweb-frontend">Github</a>
       </p>
-      <Checkbox onChange={saveDoNotShow} label="Ikke vis denne meldingen igjen" />
+      <Checkbox onChange={(checked) => saveDoNotShow(checked)} label="Ikke vis denne meldingen igjen" />
     </div>
   );
 };

--- a/src/frontpage/components/ToastOld/index.tsx
+++ b/src/frontpage/components/ToastOld/index.tsx
@@ -3,9 +3,8 @@ import React, { useEffect } from 'react';
 import { useToast } from 'core/utils/toast/useToast';
 import { Checkbox } from '@dotkomonline/design-system';
 
-
 const HIDE_TOAST = 'hideOldOWToast';
-const SESSION_HIDE_TOAST = 'hideToastForSession'
+const SESSION_HIDE_TOAST = 'hideToastForSession';
 
 const Message: React.FC = () => {
   const saveDoNotShow = (isChecked?: boolean) => {
@@ -34,13 +33,13 @@ const ToastOld: React.FC = () => {
     // This should be inside of the useEffect
     // With NextJs the window element may be null.
 
-    const permanentlyHiddenToast = window.localStorage.getItem(HIDE_TOAST) === 'true'
-    const sessionHiddenToast = window.sessionStorage.getItem(SESSION_HIDE_TOAST) === 'true'
+    const permanentlyHiddenToast = window.localStorage.getItem(HIDE_TOAST) === 'true';
+    const sessionHiddenToast = window.sessionStorage.getItem(SESSION_HIDE_TOAST) === 'true';
 
     // Blame Johannes
     if (!permanentlyHiddenToast && !sessionHiddenToast) {
       displayMessage(<Message />);
-      window.sessionStorage.setItem(SESSION_HIDE_TOAST, 'true')
+      window.sessionStorage.setItem(SESSION_HIDE_TOAST, 'true');
     }
   }, []);
   return null;

--- a/src/frontpage/components/ToastOld/index.tsx
+++ b/src/frontpage/components/ToastOld/index.tsx
@@ -4,12 +4,11 @@ import { useToast } from 'core/utils/toast/useToast';
 import { Checkbox } from '@dotkomonline/design-system';
 
 
-const SHOW_TOAST = 'showOldOWToast';
+const HIDE_TOAST = 'hideOldOWToast';
 
 const Message: React.FC = () => {
   const saveDoNotShow = (isChecked?: boolean) => {
-    console.log(isChecked);
-    window.localStorage.setItem(SHOW_TOAST, isChecked ? 'true' : 'false');
+    window.localStorage.setItem(HIDE_TOAST, isChecked ? 'true' : 'false');
   };
 
   return (
@@ -30,15 +29,13 @@ const Message: React.FC = () => {
 
 const ToastOld: React.FC = () => {
   const [displayMessage] = useToast({ type: 'basic', overwrite: true, duration: 1000 * 60 });
-  const [hasBeenShown, sethasBeenShown] = useState(false);
   useEffect(() => {
     // This should be inside of the useEffect
     // With NextJs the window element may be null.
-    const showToast = window.localStorage.getItem(SHOW_TOAST);
+    const showToast = window.localStorage.getItem(HIDE_TOAST);
     // Blame Johannes
-    if (showToast === 'true' || !showToast || !hasBeenShown) {
+    if (showToast != 'true') {
       displayMessage(<Message />);
-      sethasBeenShown(true);
     }
   }, []);
   return null;

--- a/src/frontpage/components/ToastOld/index.tsx
+++ b/src/frontpage/components/ToastOld/index.tsx
@@ -5,6 +5,7 @@ import { Checkbox } from '@dotkomonline/design-system';
 
 
 const HIDE_TOAST = 'hideOldOWToast';
+const SESSION_HIDE_TOAST = 'hideToastForSession'
 
 const Message: React.FC = () => {
   const saveDoNotShow = (isChecked?: boolean) => {
@@ -32,10 +33,14 @@ const ToastOld: React.FC = () => {
   useEffect(() => {
     // This should be inside of the useEffect
     // With NextJs the window element may be null.
-    const showToast = window.localStorage.getItem(HIDE_TOAST);
+
+    const permanentlyHiddenToast = window.localStorage.getItem(HIDE_TOAST) === 'true'
+    const sessionHiddenToast = window.sessionStorage.getItem(SESSION_HIDE_TOAST) === 'true'
+
     // Blame Johannes
-    if (showToast != 'true') {
+    if (!permanentlyHiddenToast && !sessionHiddenToast) {
       displayMessage(<Message />);
+      window.sessionStorage.setItem(SESSION_HIDE_TOAST, 'true')
     }
   }, []);
   return null;


### PR DESCRIPTION
This makes sure that the checkbox for hiding works and that you only get the toast on the first entry of the session. This coincidentally also resolves toast hell which #437 was an attempt to fix.