### PR TITLE
fix all pages with 0 count

### DIFF
--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -98,6 +98,9 @@ export async function getAllPages<T>(
   /** Get the amount of objects to get in total by fetching a single object */
   const { count }: IAPIData<T> = await get<IAPIData<T>>(query, { ...parameters, page, page_size: 1 }, options);
   /** Prepare an array with an index for each page which will be fetched */
+  if (!count) {
+    return [];
+  }
   const pageNumber = Math.ceil(count / page_size);
   const requestCount = [...Array(pageNumber)];
   /** Initialize the fetches for all the pages at the same time */


### PR DESCRIPTION
Page used to crash when the count-request was 0.
Returns an empty array instead