### PR TITLE
Add releases to Sentry through GHActions

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,0 +1,30 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Sentry-release
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  deployment:
+      types: [published]
+
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  create-sentry-release:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: Create a Sentry.io release
+      uses: tclindner/sentry-releases-action@v1.2.0
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: dotkom
+        SENTRY_PROJECT: onlineweb-frontend
+      with:
+        tagName: ${{ github.sha }}
+        environment: production
+


### PR DESCRIPTION
Notifying Sentry of releases can help us track down where new issues originate from, by sorting warnings by releases.

Docs:
https://blog.sentry.io/2019/12/17/using-github-actions-to-create-sentry-releases
https://github.com/marketplace/actions/create-a-sentry-io-release