### PR TITLE
Prevent .fulfilled on 404 by throwing upon 404

### DIFF
--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -51,7 +51,11 @@ const performRequest = async (query: string, parameters: IQueryObject = {}, opti
   try {
     data = await response.json();
   } catch {
-    throw new Error(`Expected data from ${url} to be JSON. Attempt to turn the body into JSON resulted in ${JSON.stringify(response.body)}`);
+    throw new Error(
+      `Expected data from ${url} to be JSON. Attempt to turn the body into JSON resulted in ${JSON.stringify(
+        response.body
+      )}`
+    );
   }
 
   // don't cache error responses
@@ -76,7 +80,7 @@ export const get = async <T>(
   query: string,
   parameters: IQueryObject = {},
   options: IRequestOptions = {}
-): Promise<T> =>  {
+): Promise<T> => {
   // const request = makeRequest(query, parameters, options);
   return performRequest(query, parameters, options);
 };


### PR DESCRIPTION
https://sentry.io/organizations/dotkom/issues/?project=1315187&query=is%3Aunresolved+start_date&sort=freq&statsPeriod=14d
(Hopefully handle some of these)
404 resulted in weird crashes to the Redux store because they were treated as what would have been the correct datatype, while they only had "details: Ikke funnet". Now, they are properly rejected by the redux action as errors triggers the .rejected-condition