### PR TITLE
Refetch event on login change

### DIFF
--- a/src/events/api/events.ts
+++ b/src/events/api/events.ts
@@ -36,7 +36,8 @@ export const getAllEvents = async (args: IEventAPIParameters): Promise<IEvent[]>
 };
 
 export const getEvent = async (id: number): Promise<IEvent> => {
-  const event = await get<IEvent>(EVENTS_API_URL + id + '/', { format: 'json' });
+  const user = await getUser();
+  const event = await get<IEvent>(EVENTS_API_URL + id + '/', { format: 'json' }, { user })
   return event;
 };
 

--- a/src/events/api/events.ts
+++ b/src/events/api/events.ts
@@ -37,7 +37,7 @@ export const getAllEvents = async (args: IEventAPIParameters): Promise<IEvent[]>
 
 export const getEvent = async (id: number): Promise<IEvent> => {
   const user = await getUser();
-  const event = await get<IEvent>(EVENTS_API_URL + id + '/', { format: 'json' }, { user })
+  const event = await get<IEvent>(EVENTS_API_URL + id + '/', { format: 'json' }, { user });
   return event;
 };
 

--- a/src/events/components/DetailView/index.tsx
+++ b/src/events/components/DetailView/index.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import Spinner from 'common/components/Spinner';
 import { DOMAIN } from 'common/constants/endpoints';

--- a/src/events/components/DetailView/index.tsx
+++ b/src/events/components/DetailView/index.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Spinner from 'common/components/Spinner';
 import { DOMAIN } from 'common/constants/endpoints';
@@ -13,6 +13,7 @@ import style from './detail.less';
 import InfoBox from './InfoBox';
 import PictureCard from './PictureCard';
 import Registration from './Registation';
+import { selectIsLoggedIn } from 'authentication/selectors/authentication';
 
 interface IProps {
   eventId: number;
@@ -22,12 +23,13 @@ export const DetailView = ({ eventId }: IProps) => {
   const dispatch = useDispatch();
   const event = useSelector((state) => eventSelectors.selectById(state, eventId));
   const isPending = useSelector((state) => state.events.loading === 'pending');
+  const isLoggedIn = useSelector(selectIsLoggedIn());
 
   useEffect(() => {
     window.scrollTo(0, 0);
     dispatch(fetchEventById(eventId));
     dispatch(fetchAttendanceEventById(eventId));
-  }, [eventId, dispatch]);
+  }, [eventId, dispatch, isLoggedIn]);
 
   if (isPending && !event) {
     return <Spinner />;


### PR DESCRIPTION
Resolves #463 

Events which require login and correct rights to view fetches before the user is retrieved.
This change listens on user-login and refetches the event.