### PR TITLE
Surpress handled Silent-renew errors

### DIFF
--- a/src/authentication/components/SilentRenew.tsx
+++ b/src/authentication/components/SilentRenew.tsx
@@ -20,15 +20,16 @@ export const SilentRenewComponent: FC = () => {
     if (USER_MANAGER) {
       const user = await USER_MANAGER.getUser();
       if (user) dispatch(authenticationActions.userSignIn(JSON.stringify(user as IAuthUser)));
-      else try {
-        USER_MANAGER.signinSilent();
-      } catch {
-        /*
+      else
+        try {
+          USER_MANAGER.signinSilent();
+        } catch {
+          /*
          User Manager throws "frame window timed out" or "Authorization Server requires End-User Interaction".
          If that is the case, the user will have to manually log in when the token expires.
          That is handled by the AuthenticationProvider and that is why the error is ignored here.
         */
-      }
+        }
     }
   };
 

--- a/src/authentication/components/SilentRenew.tsx
+++ b/src/authentication/components/SilentRenew.tsx
@@ -20,7 +20,15 @@ export const SilentRenewComponent: FC = () => {
     if (USER_MANAGER) {
       const user = await USER_MANAGER.getUser();
       if (user) dispatch(authenticationActions.userSignIn(JSON.stringify(user as IAuthUser)));
-      else USER_MANAGER.signinSilent();
+      else try {
+        USER_MANAGER.signinSilent();
+      } catch {
+        /*
+         User Manager throws "frame window timed out" or "Authorization Server requires End-User Interaction".
+         If that is the case, the user will have to manually log in when the token expires.
+         That is handled by the AuthenticationProvider and that is why the error is ignored here.
+        */
+      }
     }
   };
 

--- a/src/authentication/components/SilentRenew.tsx
+++ b/src/authentication/components/SilentRenew.tsx
@@ -29,7 +29,9 @@ export const SilentRenewComponent: FC = () => {
          If that is the case, the user will have to manually log in when the token expires.
          That is handled by the AuthenticationProvider and that is why the error is ignored here.
         */
-          console.warn('Automatic token refresh stopped by browser or authorization server. You need to manually login when your session expires.');
+          console.warn(
+            'Automatic token refresh stopped by browser or authorization server. You need to manually login when your session expires.'
+          );
         }
     }
   };

--- a/src/authentication/components/SilentRenew.tsx
+++ b/src/authentication/components/SilentRenew.tsx
@@ -29,6 +29,7 @@ export const SilentRenewComponent: FC = () => {
          If that is the case, the user will have to manually log in when the token expires.
          That is handled by the AuthenticationProvider and that is why the error is ignored here.
         */
+          console.warn('Automatic token refresh stopped by browser or authorization server. You need to manually login when your session expires.');
         }
     }
   };


### PR DESCRIPTION
https://sentry.io/organizations/dotkom/issues/1901156806/?project=1315187&query=is%3Aunresolved
The errors telling that the silent renew cannot be done are OK as the user will then be logged out when their access token expires, and they will then have to manually log in.
Thus, these errors can be catched instead of flooding sentry