### PR TITLE
Do not send authorization header if no token

### DIFF
--- a/src/common/utils/api.ts
+++ b/src/common/utils/api.ts
@@ -37,7 +37,7 @@ const performRequest = async (query: string, parameters: IQueryObject = {}, opti
     ...options.headers,
   } as Record<string, string>;
 
-  if (options.user) {
+  if (options.user && options.user.access_token) {
     headers['Authorization'] = `Bearer ${options.user.access_token}`;
   }
 


### PR DESCRIPTION
If a user has an expired user-object, the object's values are undefined, but the object is still present.
Thus, undefined is sent as token which breaks on calls that would still work if no authorization header was present.