### PR TITLE
Actually install packages in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
     when:
       event: [push, pull_request, tag, deployment]
     commands:
-      - npm run
+      - npm i
     depends_on:
       - restore-cache
 


### PR DESCRIPTION
A little misconfiguration was left unnoticed in the yarn to npm-transfer.
The command `yarn`'s equivalent in npm is  `npm i`. This has not been tetected due to cache if one is not changing packages.