### PR TITLE
Update Redux-store events if newer is retrieved

### DIFF
--- a/src/events/slices/events.ts
+++ b/src/events/slices/events.ts
@@ -178,7 +178,7 @@ export const eventsSlice = createSlice({
     builder.addCase(fetchEvents.fulfilled, (state, action) => {
       state.loading = 'idle';
       const events = action.payload.results;
-      eventsAdapter.addMany(state, events);
+      eventsAdapter.upsertMany(state, events);
     });
     builder.addCase(fetchEvents.rejected, (state, action) => {
       state.loading = 'idle';
@@ -189,7 +189,7 @@ export const eventsSlice = createSlice({
     });
     builder.addCase(fetchEventById.fulfilled, (state, action) => {
       state.loading = 'idle';
-      eventsAdapter.addOne(state, action.payload);
+      eventsAdapter.upsertOne(state, action.payload);
     });
     builder.addCase(fetchEventById.rejected, (state, action) => {
       state.loading = 'idle';


### PR DESCRIPTION
Fixes #481 
`addMany` does not do a deep similarity check, and thus does not update the list of events, which then looks confusing when an event is viewed directly, but then not updated in the main view. This is then done with `upsertMany` (update if present else insert = upsert)