### PR TITLE
Fixed statistics donut-labels displaying ID instead of name

### DIFF
--- a/src/events/models/Event.ts
+++ b/src/events/models/Event.ts
@@ -46,24 +46,32 @@ export const getEventType = (n: number): EventType => {
   }
 };
 
-export const getEventColor = (n: number): string => {
+export const getEventColor = (n: number | string): string => {
   switch (n) {
     case 0:
       return '#828282';
+    case 'Sosialt':
     case 1:
       return '#43B171';
+    case 'Bedriftspresentasjon':
     case 2:
       return '#EB536E';
+    case 'Kurs':
     case 3:
       return '#127DBD';
+    case 'Utflukt':
     case 4:
       return '#FDBD47';
+    case 'Ekskursjon':
     case 5:
       return '#2AC6F9';
+    case 'Internt':
     case 6:
       return '#E75E3B';
+    case 'Annet':
     case 7:
       return '#B36BCD';
+    case 'Kjelleren':
     case 8:
       return '#E75E3B';
     default:

--- a/src/profile/components/Statistics/Events/EventTypeDonut.tsx
+++ b/src/profile/components/Statistics/Events/EventTypeDonut.tsx
@@ -8,7 +8,7 @@ export interface IProps {
 }
 
 const getColor = ({ label }: PieDatum): string => {
-  return getEventColor(label); 
+  return getEventColor(label);
 };
 
 export interface ITypeCount {

--- a/src/profile/components/Statistics/Events/EventTypeDonut.tsx
+++ b/src/profile/components/Statistics/Events/EventTypeDonut.tsx
@@ -8,10 +8,7 @@ export interface IProps {
 }
 
 const getColor = ({ label }: PieDatum): string => {
-  if (typeof label === 'number') {
-    return getEventColor(label);
-  }
-  return 'gray';
+  return getEventColor(label); 
 };
 
 export interface ITypeCount {
@@ -30,7 +27,7 @@ function countEventTypes(events: IEvent[]): ITypeCount {
 
 const createPieDatum = (count: ITypeCount) => {
   return Object.keys(count).map((key) => ({
-    label: Number(key),
+    label: getEventType(Number(key)),
     value: count[key],
     id: getEventType(Number(key)),
   }));


### PR DESCRIPTION
The donut was displaying event-type ID instead of the actual name of the event. This is now fixed.