### PR TITLE
Add /offline as overview-page for offline magazine

### DIFF
--- a/src/frontpage/components/Offline/index.tsx
+++ b/src/frontpage/components/Offline/index.tsx
@@ -16,7 +16,7 @@ export interface IState {
 export const Offline = () => {
   const [offlines, setOfflines] = useState<IOfflineIssue[]>([]);
 
-  /** Get the first batch of Offlines for feast loading */
+  /** Get the first batch of Offlines for fast loading */
   const fetchInitial = async () => {
     const { results } = await getOfflines(1);
     setOfflines(results);

--- a/src/offline/components/OfflineList.tsx
+++ b/src/offline/components/OfflineList.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import ResponsiveImage from 'common/components/ResponsiveImage';
 import { IOfflineIssue } from 'frontpage/models/Offline';
 import { DateTime } from 'luxon';
@@ -21,10 +22,10 @@ const OfflineList: React.FC<Props> = ({ offlines = [] }) => {
   const offlinesAsSections = Object.entries(offlinesPerYear)
     .reverse()
     .map(([year, offlines]) => (
-      <section>
+      <section key={year}>
         <h3>{year}</h3>
         {offlines.map((offline) => (
-          <a href={offline.issue} className={style.offline}>
+          <a href={offline.issue} className={style.offline} key={offline.release_date}>
             <ResponsiveImage image={offline.image} size="xs" type="offline" />
           </a>
         ))}

--- a/src/offline/components/OfflineList.tsx
+++ b/src/offline/components/OfflineList.tsx
@@ -1,0 +1,36 @@
+import ResponsiveImage from 'common/components/ResponsiveImage';
+import { IOfflineIssue } from 'frontpage/models/Offline';
+import { DateTime } from 'luxon';
+import style from './style.less';
+
+interface Props {
+  offlines?: IOfflineIssue[];
+}
+
+const getReleaseYear = (offlineIssue: IOfflineIssue) => DateTime.fromISO(offlineIssue.release_date).year;
+
+const OfflineList: React.FC<Props> = ({ offlines = [] }) => {
+  const offlinesPerYear = offlines.reduce((offlineRecord, offlineIssue) => {
+    const year = getReleaseYear(offlineIssue);
+    Array.isArray(offlineRecord[year])
+      ? offlineRecord[year].push(offlineIssue)
+      : (offlineRecord[year] = [offlineIssue]);
+    return offlineRecord;
+  }, {} as Record<number, IOfflineIssue[]>);
+
+  const offlinesAsSections = Object.entries(offlinesPerYear)
+    .reverse()
+    .map(([year, offlines]) => (
+      <section>
+        <h3>{year}</h3>
+        {offlines.map((offline) => (
+          <a href={offline.issue} className={style.offline}>
+            <ResponsiveImage image={offline.image} size="xs" type="offline" />
+          </a>
+        ))}
+      </section>
+    ));
+  return <>{offlinesAsSections}</>;
+};
+
+export default OfflineList;

--- a/src/offline/components/style.less
+++ b/src/offline/components/style.less
@@ -1,0 +1,20 @@
+@import '~common/less/constants.less';
+
+.offline {
+  margin: 0 5px;
+  width: 200px;
+  overflow: hidden;
+  display: inline-block;
+
+  @media screen and (max-width: @owMobileBreakpoint) {
+    width: 150px;
+  }
+
+  > img {
+    transition: transform 0.5s;
+
+    &:hover {
+      transform: scale(1.1);
+    }
+  }
+}

--- a/src/offline/index.tsx
+++ b/src/offline/index.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+
+import { getOfflines, getRemainingOfflines } from 'frontpage/api/offline';
+import { IOfflineIssue } from 'frontpage/models/Offline';
+import OfflineList from './components/OfflineList';
+import Spinner from 'common/components/Spinner';
+
+export const Offline: React.FC = () => {
+  const [offlines, setOfflines] = useState<IOfflineIssue[]>([]);
+
+  /** Get the first batch of Offlines for feast loading */
+  const fetchInitial = async () => {
+    const { results } = await getOfflines(1);
+    setOfflines(results);
+    fetchRemaining();
+  };
+
+  /** Get all the remaining Offlines to fill out the list */
+  const fetchRemaining = async () => {
+    const remaining = await getRemainingOfflines();
+    setOfflines(remaining);
+  };
+
+  /** Fetch offlines on first mount */
+  useEffect(() => {
+    fetchInitial();
+  }, []);
+  return offlines.length ? <OfflineList offlines={offlines} /> : <Spinner />;
+};
+
+export default Offline;

--- a/src/offline/index.tsx
+++ b/src/offline/index.tsx
@@ -8,7 +8,7 @@ import Spinner from 'common/components/Spinner';
 export const Offline: React.FC = () => {
   const [offlines, setOfflines] = useState<IOfflineIssue[]>([]);
 
-  /** Get the first batch of Offlines for feast loading */
+  /** Get the first batch of Offlines for fast loading */
   const fetchInitial = async () => {
     const { results } = await getOfflines(1);
     setOfflines(results);

--- a/src/pages/offline/index.tsx
+++ b/src/pages/offline/index.tsx
@@ -1,0 +1,19 @@
+import Heading from 'common/components/Heading';
+import { IOfflineIssue } from 'frontpage/models/Offline';
+import Offline from 'offline';
+import React, { FC } from 'react';
+
+interface ServerSideProps {
+  offlines?: IOfflineIssue[];
+}
+
+const Offlines: FC<ServerSideProps> = () => {
+  return (
+    <section>
+      <Heading title="Offlines" />
+      <Offline />
+    </section>
+  );
+};
+
+export default Offlines;


### PR DESCRIPTION
We have an "archive" of old offlines at old, and would like for this to be present at OWF as well.
This is nice to have if you want to view old offlines without navigating the frontpage.