### PR TITLE
Attendance event breakpoints

### DIFF
--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -47,15 +47,15 @@ const AttendanceEvent: FC<IProps> = ({ eventId, eventTitle }) => {
 
   return (
     <div className={style.blockGrid}>
-      <Block title="Påmeldingsstart">
+      <Block title="Påmeldingsstart" className={style.attendanceInformation}>
         <EventCountDown endTime={registrationStart} />
       </Block>
 
-      <Block title="Påmeldingslutt">
+      <Block title="Påmeldingslutt" className={style.attendanceInformation}>
         <EventCountDown endTime={registrationEnd} />
       </Block>
 
-      <Block title="Avmeldingsfrist">
+      <Block title="Avmeldingsfrist" className={style.attendanceInformation}>
         <EventCountDown endTime={cancellationDeadline} />
       </Block>
 

--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -51,7 +51,7 @@ const AttendanceEvent: FC<IProps> = ({ eventId, eventTitle }) => {
         <EventCountDown endTime={registrationStart} />
       </Block>
 
-      <Block title="Påmeldingslutt" className={style.attendanceInformation}>
+      <Block title="Påmeldingsslutt" className={style.attendanceInformation}>
         <EventCountDown endTime={registrationEnd} />
       </Block>
 

--- a/src/events/components/DetailView/PublicAttendeesModal/ParticipantsButton.tsx
+++ b/src/events/components/DetailView/PublicAttendeesModal/ParticipantsButton.tsx
@@ -39,7 +39,7 @@ export const ParticipantsButton: FC<IProps> = ({ eventId, eventTitle }) => {
     <>
       <Button onClick={toggleModal}>Vis påmeldte</Button>
       <Modal open={showModal} onClose={toggleModal}>
-        <h1>Påmeldingliste for {eventTitle}</h1>
+        <h1>Påmeldingsliste for {eventTitle}</h1>
         <AttendeeList attendees={attendees} />
       </Modal>
     </>

--- a/src/events/components/DetailView/detail.less
+++ b/src/events/components/DetailView/detail.less
@@ -66,6 +66,12 @@
   flex-wrap: wrap;
   justify-content: center;
 
+  .attendanceInformation {
+    flex: 1;
+    margin-right: 3px;
+    margin-left: 3px;
+  }
+
   > div {
     width: 50%;
   }


### PR DESCRIPTION
- Fixes spelling mistake, "Påmeldingliste" -> "Påmeldingsliste"
- Adds margin to certain Blocks in order to trigger an earlier breakpoint for flex-wrap

Previous:
![image](https://user-images.githubusercontent.com/15364176/96098434-6546ec80-0ed2-11eb-982f-bea88a77a0e2.png)

Suggestion:
![image](https://user-images.githubusercontent.com/15364176/96098487-72fc7200-0ed2-11eb-9540-7de945303938.png)

closes #514 