### PR TITLE
Made word breaking only apply to links and improved browser support

### DIFF
--- a/src/events/components/DetailView/detail.less
+++ b/src/events/components/DetailView/detail.less
@@ -88,8 +88,9 @@
   padding: 30px;
 }
 
-.infoBox {
-  word-wrap: anywhere;
+.infoBox a {
+  overflow-wrap: break-word;
+  word-break: break-word;
   hyphens: auto;
 }
 


### PR DESCRIPTION
#553
Made css word breaking rules only apply to links and not all of the text to avoid unnatural word breaks. Also switched to rules that are better supported. 

Example of the unnatural word breaking that is currently happeninng on event pages:
![image](https://user-images.githubusercontent.com/55615149/115958418-bbdb5600-a507-11eb-88f1-b5cf34cccef9.png)


Words of approximately this size "wwwwwwwwwwwwwwwwwwwwwww" that are not part of links still break the layout on mobile. 
