### PR TITLE
Fixed attendees scrolling issue on Safari

### DIFF
--- a/src/events/components/DetailView/PublicAttendeesModal/PublicAttendees.less
+++ b/src/events/components/DetailView/PublicAttendeesModal/PublicAttendees.less
@@ -4,4 +4,5 @@
   display: flex;
   flex-direction: column;
   margin-top: 40px; // More spacing before the cards
+  max-height: 65vh;
 }


### PR DESCRIPTION
- Added max-height to grid element to prevent overflow on Safari