### PR TITLE
Add WIP iCal and Google Calendar imports in frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-less": "^1.0.1",
     "abortcontroller-polyfill": "^1.2.3",
+    "axios": "^0.22.0",
     "babel-jest": "^24.1.0",
     "classnames": "^2.2.5",
     "file-loader": "^6.0.0",

--- a/src/events/components/DetailView/ExportDropdown.tsx
+++ b/src/events/components/DetailView/ExportDropdown.tsx
@@ -1,0 +1,85 @@
+import { IEvent } from 'events/models/Event';
+import React, { useState } from 'react';
+import styles from './detail.less';
+import axios from 'axios';
+import Select from '@dotkomonline/design-system/dist/components/select/Select';
+import Link from 'next/link';
+
+interface ExportDropdownProps {
+  event: IEvent;
+}
+
+interface IGoogleCalendarInsertEvent {
+  end: {
+    dateTime: Date;
+  };
+  start: {
+    dateTime: Date;
+  };
+}
+
+const ExportDropdown = ({ event }: ExportDropdownProps) => {
+  // State management
+  const [iCalHref, setICalHref] = useState('');
+
+  // Check the NODE_ENV, and determine if we're in development or production.
+  const isDevelopment = process.env.NODE_ENV !== 'production';
+
+  // Build calendarUrl based on the NODE_ENV
+  const iCalUrl = isDevelopment
+    ? `localhost:8000/api/v1/event/events/${event.id}/calendar`
+    : `https://online.ntnu.no/api/v1/event/events/${event.id}/calendar`;
+
+  const handleICal = () => {
+    const response = axios({
+      url: iCalUrl,
+      method: 'GET', // !: Maybe this should be POST, we'll see
+      responseType: 'blob', // Specifying that this is a binary large object is important when a file is downloaded from endpoint
+    })
+      .then((response) => {
+        const url = URL.createObjectURL(new Blob([response.data]));
+        setICalHref(url);
+      })
+      .catch((error) => {
+        // TODO: Proper error handling
+        console.log(`❌ An error occurred: ${error.message}`);
+      });
+  };
+
+  const handleGoogleCalendar = () => {
+    const requestBody: IGoogleCalendarInsertEvent = {
+      start: {
+        dateTime: new Date(event.start_date),
+      },
+      end: {
+        dateTime: new Date(event.end_date),
+      },
+    };
+
+    const response = axios
+      .post(`https://www.googleapis.com/calendar/v3/calendars/${event.id}/events`, requestBody)
+      .then((response) => {
+        // TODO: Proper handling
+        console.log(response);
+      })
+      .catch((error) => {
+        // TODO: Proper  error handling
+        console.error(error);
+      });
+  };
+
+  return (
+    <div className={styles.export}>
+      <Select>
+        <option value="{iCal}" onClick={handleICal}>
+          <Link href={iCalHref}>iCal</Link>
+        </option>
+        <option value="{Google Calendar}" onClick={handleGoogleCalendar}>
+          Google Calendar
+        </option>
+      </Select>
+    </div>
+  );
+};
+
+export default ExportDropdown;

--- a/src/events/components/DetailView/Registation.tsx
+++ b/src/events/components/DetailView/Registation.tsx
@@ -5,6 +5,7 @@ import { getEventColor, IEvent } from 'events/models/Event';
 import AttendanceEvent from './AttendanceEvent';
 import CardHeader from './Card/CardHeader';
 import styles from './detail.less';
+import ExportDropdown from './ExportDropdown';
 
 interface IProps {
   event: IEvent;
@@ -17,6 +18,7 @@ const Registration: FC<IProps> = ({ event }) => {
       <CardHeader className={styles.detailHeader} color={color}>
         Påmelding
       </CardHeader>
+      <ExportDropdown event={event} />
       <AttendanceEvent eventId={event.id} eventTitle={event.title} />
     </div>
   );

--- a/src/events/components/DetailView/detail.less
+++ b/src/events/components/DetailView/detail.less
@@ -152,3 +152,19 @@
 .priceBlock {
   text-align: center;
 }
+
+.export {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  a {
+    padding: 1em;
+  }
+
+  a:hover {
+    color: @blue;
+    font-weight: bold;
+    cursor: pointer;
+  }
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -11,6 +11,8 @@ const getInitialProps = async (ctx: DocumentContext): Promise<DocumentInitialPro
   try {
     ctx.renderPage = () => {
       return originalRenderPage({
+        // TODO: Remove before merging. Only used for local development.
+        // eslint-disable-next-line react/display-name
         enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
       });
     };


### PR DESCRIPTION
Closes: #567

**Changelog**
- When the user clicks on an event, the user is taken to that event's index page. The user then selects either _iCal_ or _Google Calendar_ from a dropdown.
- If _iCal_ is selected, the frontend queries the backend for a `.ics` file.
- If _Google Calendar_ is selected, the future plan is to send a `POST` request to the Google Calendar API.