### PR TITLE
Fix/#601 profile empty address

### DIFF
--- a/src/__tests__/fmt.ts
+++ b/src/__tests__/fmt.ts
@@ -8,3 +8,4 @@ test('String and number argument in reverse order', () => expect(fmt('{1} {0}', 
 test('Undefined argument', () => expect(fmt('{0} {1}', 'Henrik', undefined)).toBe(DEFAULT));
 test('Null argument', () => expect(fmt('{0} {1}', 'Henrik', null)).toBe(DEFAULT));
 test('Badly formatted formatstring', () => expect(() => fmt('{0} {1', 'Henrik', 'Skog')).toThrow());
+test('Badly formatted formatstring', () => expect(() => fmt('{x} {1', 'Henrik', 'Skog')).toThrow());

--- a/src/__tests__/fmt.ts
+++ b/src/__tests__/fmt.ts
@@ -7,3 +7,4 @@ test('Two string arguments', () => expect(fmt('{0} {1}', 'Henrik', 'Skog')).toBe
 test('String and number argument in reverse order', () => expect(fmt('{1} {0}', 'Henrik', 123)).toBe('123 Henrik'));
 test('Undefined argument', () => expect(fmt('{0} {1}', 'Henrik', undefined)).toBe(DEFAULT));
 test('Null argument', () => expect(fmt('{0} {1}', 'Henrik', null)).toBe(DEFAULT));
+test('Badly formatted formatstring', () => expect(() => fmt('{0} {1', 'Henrik', 'Skog')).toThrow());

--- a/src/__tests__/fmt.ts
+++ b/src/__tests__/fmt.ts
@@ -1,0 +1,9 @@
+import fmt from 'profile/utils/stringFormat';
+
+const DEFAULT = 'Ikke tilgjengelig';
+test('empty string', () => expect(fmt('')).toBe(''));
+test('empty string', () => expect(fmt('{0}', 0)).toBe('0'));
+test('empty string', () => expect(fmt('{0} {1}', 'Henrik', 'Skog')).toBe('Henrik Skog'));
+test('hello', () => expect(fmt('{1} {0}', 'Henrik', 123)).toBe('123 Henrik'));
+test('hello', () => expect(fmt('{0} {1}', 'Henrik', undefined)).toBe(DEFAULT));
+test('hello', () => expect(fmt('{0} {1}', 'Henrik', null)).toBe(DEFAULT));

--- a/src/__tests__/fmt.ts
+++ b/src/__tests__/fmt.ts
@@ -1,9 +1,9 @@
 import fmt from 'profile/utils/stringFormat';
 
 const DEFAULT = 'Ikke tilgjengelig';
-test('empty string', () => expect(fmt('')).toBe(''));
-test('empty string', () => expect(fmt('{0}', 0)).toBe('0'));
-test('empty string', () => expect(fmt('{0} {1}', 'Henrik', 'Skog')).toBe('Henrik Skog'));
-test('hello', () => expect(fmt('{1} {0}', 'Henrik', 123)).toBe('123 Henrik'));
-test('hello', () => expect(fmt('{0} {1}', 'Henrik', undefined)).toBe(DEFAULT));
-test('hello', () => expect(fmt('{0} {1}', 'Henrik', null)).toBe(DEFAULT));
+test('Empty string', () => expect(fmt('')).toBe(''));
+test('Number', () => expect(fmt('{0}', 0)).toBe('0'));
+test('Two string arguments', () => expect(fmt('{0} {1}', 'Henrik', 'Skog')).toBe('Henrik Skog'));
+test('String and number argument in reverse order', () => expect(fmt('{1} {0}', 'Henrik', 123)).toBe('123 Henrik'));
+test('Undefined argument', () => expect(fmt('{0} {1}', 'Henrik', undefined)).toBe(DEFAULT));
+test('Null argument', () => expect(fmt('{0} {1}', 'Henrik', null)).toBe(DEFAULT));

--- a/src/profile/components/Settings/SettingsInfo.tsx
+++ b/src/profile/components/Settings/SettingsInfo.tsx
@@ -5,6 +5,7 @@ import { getProfile } from 'profile/api';
 import { IUserProfile } from 'profile/models/User';
 import { useEffect, useState } from 'react';
 import KeyValue from '../Profile/KeyValue';
+import fmt from 'profile/utils/stringFormat';
 
 const MAIN_INFO_TEXT = `
   # Innstillinger
@@ -30,9 +31,9 @@ const SettingsInfo = () => {
       <Markdown source={MAIN_INFO_TEXT} />
       {profile ? (
         <>
-          <KeyValue k="Navn" v={`${profile.first_name} ${profile.last_name}`} bold />
-          <KeyValue k="Klassetrinn" v={`${profile.year}. klasse`} bold />
-          <KeyValue k="Adresse" v={`${profile.address}, ${profile.zip_code} ${profile.city}`} bold />
+          <KeyValue k="Navn" v={fmt('{0} {1}', profile.first_name, profile.last_name)} bold />
+          <KeyValue k="Klassetrinn" v={fmt('{0}. klasse', profile.year)} bold />
+          <KeyValue k="Adresse" v={fmt('{0} {1} {2}', profile.address, profile.zip_code, profile.city)} bold />
           <KeyValue k="Telefon" v={profile.phone_number} bold />
           <KeyValue k="Kallenavn" v={profile.nickname} bold />
           <KeyValue k="NTNU-brukernavn" v={profile.ntnu_username} bold />

--- a/src/profile/utils/stringFormat.ts
+++ b/src/profile/utils/stringFormat.ts
@@ -18,7 +18,7 @@ const fmt = (frmtStr: string, ...args: (string | number | undefined | null)[]): 
     if (frmtStr[strIdx] == '{') {
       //validate
       if (frmtStr[strIdx + 2] != '}') throw new Error('A "{" is missing a matching "}"');
-      if (typeof frmtStr[strIdx + 1] != 'number') throw new Error('Badly formatted format string');
+      if (isNaN(parseFloat(frmtStr[strIdx + 1]))) throw new Error('Badly formatted format string');
 
       // Concatting a number to a string returns string in js
       res += args[Number(frmtStr[strIdx + 1])];

--- a/src/profile/utils/stringFormat.ts
+++ b/src/profile/utils/stringFormat.ts
@@ -2,6 +2,7 @@
  * Formats a string like the python .format with default fallback
  * @description
  * Format a string with variables and resolves the string to a default value if one of the variables are null/undefined.
+ * String cannot include a {
  * @example
  * fmt('Navn: {0} {1}', 'Fornavn', 'Etternavn')) => 'Navn: Fornavn Etternavn'
  * fmt('Navn: {0} {1}', 'Fornavn', undefined)) => 'Ikke tilgjengelig'

--- a/src/profile/utils/stringFormat.ts
+++ b/src/profile/utils/stringFormat.ts
@@ -7,7 +7,7 @@
  * fmt('Navn: {0} {1}', 'Fornavn', undefined)) => 'Ikke tilgjengelig'
  */
 const fmt = (frmtStr: string, ...args: (string | number | undefined | null)[]): string => {
-  if (args.filter((el) => el == undefined || el == null).length) return 'Ikke tilgjengelig';
+  if (args.filter((el) => el == null).length) return 'Ikke tilgjengelig';
 
   let res = '';
   let strIdx = 0;

--- a/src/profile/utils/stringFormat.ts
+++ b/src/profile/utils/stringFormat.ts
@@ -2,7 +2,9 @@
  * Formats a string like the python .format with default fallback
  * @description
  * Format a string with variables and resolves the string to a default value if one of the variables are null/undefined.
- * String cannot include a {
+ * NB: Funciton has certain limitations:
+ * 1. String cannot include a {
+ * 2. String cannot include a {
  * @example
  * fmt('Navn: {0} {1}', 'Fornavn', 'Etternavn')) => 'Navn: Fornavn Etternavn'
  * fmt('Navn: {0} {1}', 'Fornavn', undefined)) => 'Ikke tilgjengelig'
@@ -16,6 +18,8 @@ const fmt = (frmtStr: string, ...args: (string | number | undefined | null)[]): 
     if (frmtStr[strIdx] == '{') {
       //validate
       if (frmtStr[strIdx + 2] != '}') throw new Error('A "{" is missing a matching "}"');
+      if (typeof frmtStr[strIdx + 1] != 'number') throw new Error('Badly formatted format string');
+
       // Concatting a number to a string returns string in js
       res += args[Number(frmtStr[strIdx + 1])];
       strIdx += 3;

--- a/src/profile/utils/stringFormat.ts
+++ b/src/profile/utils/stringFormat.ts
@@ -14,6 +14,8 @@ const fmt = (frmtStr: string, ...args: (string | number | undefined | null)[]): 
   let strIdx = 0;
   while (strIdx < frmtStr.length) {
     if (frmtStr[strIdx] == '{') {
+      //validate
+      if (frmtStr[strIdx + 2] != '}') throw new Error('A "{" is missing a matching "}"');
       // Concatting a number to a string returns string in js
       res += args[Number(frmtStr[strIdx + 1])];
       strIdx += 3;

--- a/src/profile/utils/stringFormat.ts
+++ b/src/profile/utils/stringFormat.ts
@@ -1,0 +1,27 @@
+/**
+ * Formats a string like the python .format with default fallback
+ * @description
+ * Format a string with variables and resolves the string to a default value if one of the variables are null/undefined.
+ * @example
+ * fmt('Navn: {0} {1}', 'Fornavn', 'Etternavn')) => 'Navn: Fornavn Etternavn'
+ * fmt('Navn: {0} {1}', 'Fornavn', undefined)) => 'Ikke tilgjengelig'
+ */
+const fmt = (frmtStr: string, ...args: (string | number | undefined | null)[]): string => {
+  if (args.filter((el) => el == undefined || el == null).length) return 'Ikke tilgjengelig';
+
+  let res = '';
+  let strIdx = 0;
+  while (strIdx < frmtStr.length) {
+    if (frmtStr[strIdx] == '{') {
+      // Concatting a number to a string returns string in js
+      res += args[Number(frmtStr[strIdx + 1])];
+      strIdx += 3;
+    } else {
+      res += frmtStr[strIdx];
+      strIdx++;
+    }
+  }
+  return res;
+};
+
+export default fmt;


### PR DESCRIPTION
Closes: #601 

**Changelog**
1. Add util function that formats a string with variables, but that falls back to a default value if one of the variables are null/undefined.
2. Test function
3. Use function in Profile Settings where issue bug exists

**why**
- clean way to render the key value props in settings page in profile
- fixes issue where null/undifined are rendered to the website as strings

**example**
 * fmt('Navn: {0} {1}', 'Fornavn', 'Etternavn')) => 'Navn: Fornavn Etternavn'
 * fmt('Navn: {0} {1}', 'Fornavn', undefined)) => 'Ikke tilgjengelig'



**Possible issues**
- Bit of duplication of code, it is also checked for null values in the KeyValue component, but that does not work for strings with multiple variables
- **I have not been able to check that it works**
    - I have not been able to log in in development. 

**Important before merge**
- Check that it works in development