### PR TITLE
Min height on event image on front page

### DIFF
--- a/src/events/components/ImageView/LargeEvent.tsx
+++ b/src/events/components/ImageView/LargeEvent.tsx
@@ -29,7 +29,9 @@ const LargeEvent: FC<IProps> = ({ eventId }) => {
           <h2 className={style.imageLargeType} style={{ background: color }}>
             {event_type_display}
           </h2>
-          <EventImage images={images} color={color} />
+          <div className={style.imageContainer}>
+            <EventImage images={images} color={color} />
+          </div>
           <div className={style.largeContent}>
             <span style={{ background: color }} />
             <p>{title}</p>

--- a/src/events/components/ImageView/image.less
+++ b/src/events/components/ImageView/image.less
@@ -4,6 +4,10 @@
 @edge-height: 20px;
 @colorIndicatorSize: 0.5rem;
 
+.imageContainer {
+  height: 220px;
+}
+
 .eventGrid {
   display: grid;
   grid-template-columns: 1fr;
@@ -69,7 +73,7 @@
   font-size: @owFontM;
   text-align: center;
   color: @gray;
-  min-height: 4rem;
+  min-height: 100rem;
 }
 
 .largeContent,

--- a/src/events/components/ImageView/image.less
+++ b/src/events/components/ImageView/image.less
@@ -5,7 +5,7 @@
 @colorIndicatorSize: 0.5rem;
 
 .imageContainer {
-  height: 220px;
+  min-height: 220px;
 }
 
 .eventGrid {

--- a/src/events/components/ImageView/image.less
+++ b/src/events/components/ImageView/image.less
@@ -73,7 +73,7 @@
   font-size: @owFontM;
   text-align: center;
   color: @gray;
-  min-height: 100rem;
+  min-height: 4rem;
 }
 
 .largeContent,


### PR DESCRIPTION
**BEFORE**
<img width="1429" alt="image" src="https://user-images.githubusercontent.com/55615149/154863103-e6081888-ee80-4067-82a7-97b599678e62.png">

**AFTER**
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/55615149/154863148-e45799e9-91e6-4eec-ba28-1803edd6d5d3.png">


**NB**
- The issue with only 3 events in rightmost column is fixed in #603 