### PR TITLE
fix: scrolling issue

### DIFF
--- a/src/events/components/DetailView/PublicAttendeesModal/ParticipantsButton.tsx
+++ b/src/events/components/DetailView/PublicAttendeesModal/ParticipantsButton.tsx
@@ -35,6 +35,10 @@ export const ParticipantsButton: FC<IProps> = ({ eventId, eventTitle }) => {
     dispatch(fetchPublicAttendeesByEventId(eventId));
   }, [eventId]);
 
+  useEffect(() => {
+    document.body.style.overflowY = showModal ? 'hidden' : 'auto';
+  }, [showModal]);
+
   return (
     <>
       <Button onClick={toggleModal}>Vis påmeldte</Button>

--- a/src/events/components/DetailView/PublicAttendeesModal/ParticipantsButton.tsx
+++ b/src/events/components/DetailView/PublicAttendeesModal/ParticipantsButton.tsx
@@ -37,7 +37,7 @@ export const ParticipantsButton: FC<IProps> = ({ eventId, eventTitle }) => {
 
   // disables background scrolling when the modal is open
   useEffect(() => {
-    document.body.style.overflowY = showModal ? 'hidden' : 'auto';
+    document.body.style.overflow = showModal ? 'hidden' : 'auto';
   }, [showModal]);
 
   return (

--- a/src/events/components/DetailView/PublicAttendeesModal/ParticipantsButton.tsx
+++ b/src/events/components/DetailView/PublicAttendeesModal/ParticipantsButton.tsx
@@ -35,6 +35,7 @@ export const ParticipantsButton: FC<IProps> = ({ eventId, eventTitle }) => {
     dispatch(fetchPublicAttendeesByEventId(eventId));
   }, [eventId]);
 
+  // disables background scrolling when the modal is open
   useEffect(() => {
     document.body.style.overflowY = showModal ? 'hidden' : 'auto';
   }, [showModal]);


### PR DESCRIPTION
Closes: #605 

**Changelog**
Disable y-overflow on body when "show attendees" modal is active. Effectively disables scroll of the background.