### PR TITLE
Fix Bekk logo overflowing mobile front page

### DIFF
--- a/src/core/components/Header/header.less
+++ b/src/core/components/Header/header.less
@@ -261,22 +261,26 @@
 }
 
 .bekk {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  width: 150px;
-}
-
-.bekkLogo {
-  width: 100px;
+  width: 65px;
   height: 40px;
+  margin-left: 20px;
 
-  @media (max-width: @owDesktopMaxWidth) {
+  @media (min-width: 1150px) {
+    width: 100px;
+    display: inline-block;
+  }
+
+  @media (min-width: @owTabletBreakpoint) and (max-width: 1080px) {
     display: none;
   }
 
-  @media (max-width: @owTabletBreakpoint) {
-    display: unset;
+  // smaller than iPhone SE
+  @media (max-width: 375px) {
+    width: 40px;
   }
+}
+
+.bekkLogo {
+  width: 100%;
+  height: 40px;
 }


### PR DESCRIPTION
Smaller logo on mobile to prevent overflow and small refactor of css