### PR TITLE
Fix capitalization on statistics page

### DIFF
--- a/src/profile/components/Statistics/Orders/index.tsx
+++ b/src/profile/components/Statistics/Orders/index.tsx
@@ -37,10 +37,10 @@ export const Orders: FC = () => {
         <Pane>{orderLines.length && <OrderItemDonut orderLines={orderLines} />}</Pane>
         <FourSplitPane>
           <Pane>
-            <NumberStat name="Antall Kjøp" value={totalOrderLines} />
+            <NumberStat name="Antall kjøp" value={totalOrderLines} />
           </Pane>
           <Pane>
-            <NumberStat name="Antall Enheter" value={totalItems} />
+            <NumberStat name="Antall enheter" value={totalItems} />
           </Pane>
           <Pane>
             <AccountBalance />


### PR DESCRIPTION
"Kjøp" and "Enheter" should be lowercase in order to comply with Norwegian capitalization rules. This change also enforces consistency between the mentioned elements and the totalCost element, which is already correctly capitalized.