### PR TITLE
Add prikkeregler text and link to EventDetailView

### DIFF
--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -98,10 +98,12 @@ const AttendanceEvent: FC<IProps> = ({ eventId, eventTitle }) => {
           />
         </Block>
       )}
-      {isEligibleForSignup && (isEligibleForSignup.status) && (
+      {isEligibleForSignup && isEligibleForSignup.status && (
         <div className={`${style.agreeRules} ${style.fullBlock}`}>
           <p>Ved å melde deg på godtar du</p>
-          <a href="https://old.online.ntnu.no/wiki/online/info/innsikt-og-interface/prikkeregler/">Onlines prikkeregler</a>
+          <a href="https://old.online.ntnu.no/wiki/online/info/innsikt-og-interface/prikkeregler/">
+            Onlines prikkeregler
+          </a>
         </div>
       )}
       <div className={`${style.attendanceContainer} ${style.fullBlock}`}>

--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -101,7 +101,7 @@ const AttendanceEvent: FC<IProps> = ({ eventId, eventTitle }) => {
       {isEligibleForSignup && (isEligibleForSignup.status) && (
         <div className={`${style.agreeRules} ${style.fullBlock}`}>
           <p>Ved å melde deg på godtar du</p>
-          <a href="https://old.online.ntnu.no/wiki/online/info/innsikt-og-interface/prikkeregler/">Onlines prikkregler</a>
+          <a href="https://old.online.ntnu.no/wiki/online/info/innsikt-og-interface/prikkeregler/">Onlines prikkeregler</a>
         </div>
       )}
       <div className={`${style.attendanceContainer} ${style.fullBlock}`}>

--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -98,6 +98,12 @@ const AttendanceEvent: FC<IProps> = ({ eventId, eventTitle }) => {
           />
         </Block>
       )}
+      {isEligibleForSignup && (isEligibleForSignup.status) && (
+        <div className={`${style.agreeRules} ${style.fullBlock}`}>
+          <p>Ved å melde deg på godtar du</p>
+          <a href="https://old.online.ntnu.no/wiki/online/info/innsikt-og-interface/prikkeregler/">Onlines prikkregler</a>
+        </div>
+      )}
       <div className={`${style.attendanceContainer} ${style.fullBlock}`}>
         <Attendance canAttend={isEligibleForSignup} event={attendanceEvent} unattendDeadline={cancellationDeadline} />
         <PublicAttendeesWrapper isAttending={attendanceEvent.is_attendee} canAttend={isEligibleForSignup}>

--- a/src/events/components/DetailView/detail.less
+++ b/src/events/components/DetailView/detail.less
@@ -129,6 +129,19 @@
   margin: 4px;
 }
 
+.agreeRules {
+  margin-top: 15px;
+  text-align: center;
+
+  > a {
+    color: @blue;
+
+    &:hover {
+      color: lighten(@blue, 10%);
+    }
+  }
+}
+
 .detailHeader {
   text-align: center;
 }


### PR DESCRIPTION
# Changes
- Added text saying you agree to the "prikkeregler" before registering for an event. The link points to the [wiki page](https://old.online.ntnu.no/wiki/online/info/innsikt-og-interface/prikkeregler/). This feature was requested by arrkom. 

![image](https://user-images.githubusercontent.com/40792825/204114752-7728fb43-73d7-4535-be29-5a4ab3f1ccd5.png)
