### PR TITLE
Add button for adding event to cal

### DIFF
--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -16,7 +16,7 @@ import Attendance from '../Attendance';
 import { attendeeSelectors, fetchAttendeeByEventId, patchAttendee } from 'events/slices/attendees';
 import EventPaymentBlock from '../EventPayment/EventPaymentBlock';
 import EventPrice from '../EventPayment/EventPrice';
-import { Select } from '@dotkomonline/design-system';
+import { Button, Select } from '@dotkomonline/design-system';
 import { IExtra } from '../../models/Extras';
 import PublicAttendeesWrapper from './PublicAttendeesModal/PublicAttendeesWrapper';
 import ParticipantsButton from './PublicAttendeesModal/ParticipantsButton';
@@ -109,6 +109,9 @@ const AttendanceEvent: FC<IProps> = ({ eventId, eventTitle }) => {
         <PublicAttendeesWrapper isAttending={attendanceEvent.is_attendee} canAttend={isEligibleForSignup}>
           <ParticipantsButton eventTitle={eventTitle} eventId={eventId} />
         </PublicAttendeesWrapper>
+        <a href={`https://old.online.ntnu.no/events/${eventId}.ics`} className={style.calendarButton}>
+          <Button variant="outline">Legg til i kalender</Button>
+        </a>
       </div>
       {attendanceEvent.payment && (
         <Block title="Pris" className={`${style.fullBlock} ${style.priceBlock}`}>

--- a/src/events/components/DetailView/AttendanceEvent.tsx
+++ b/src/events/components/DetailView/AttendanceEvent.tsx
@@ -109,9 +109,11 @@ const AttendanceEvent: FC<IProps> = ({ eventId, eventTitle }) => {
         <PublicAttendeesWrapper isAttending={attendanceEvent.is_attendee} canAttend={isEligibleForSignup}>
           <ParticipantsButton eventTitle={eventTitle} eventId={eventId} />
         </PublicAttendeesWrapper>
-        <a href={`https://old.online.ntnu.no/events/${eventId}.ics`} className={style.calendarButton}>
-          <Button variant="outline">Legg til i kalender</Button>
-        </a>
+        {attendanceEvent.is_attendee && (
+          <a href={`https://old.online.ntnu.no/events/${eventId}.ics`} className={style.calendarButton}>
+            <Button variant="outline">Legg til i kalender</Button>
+          </a>
+        )}
       </div>
       {attendanceEvent.payment && (
         <Block title="Pris" className={`${style.fullBlock} ${style.priceBlock}`}>

--- a/src/events/components/DetailView/detail.less
+++ b/src/events/components/DetailView/detail.less
@@ -165,3 +165,11 @@
 .priceBlock {
   text-align: center;
 }
+
+.calendarButton {
+  margin-top: 1em;
+}
+
+.calendarButton > button {
+  width: 100%;
+}


### PR DESCRIPTION
CLOSES: https://github.com/dotkom/onlineweb-frontend/issues/672#issue-1664898704, #516


### Hva som legges til
Vis knapp for å laste ned event-info til kalender på arrangementer bruker er meldt på. 

### Implementasjon
Laster ned ics-fil. Bruker api-endepunkt på ow4: old.online.ntnu.no/events/{id}.ics

Tar veeeeldig gjerne imot styling-feedback

![image](https://github.com/dotkom/onlineweb-frontend/assets/55615149/ff7afca5-98ef-4f5b-a0da-4db859be279e)
