### PR TITLE
Don't let users add more money to account due to move to vipps

### DIFF
--- a/src/payments/components/Wallet/index.tsx
+++ b/src/payments/components/Wallet/index.tsx
@@ -1,24 +1,34 @@
-import React, { FC } from 'react';
+import React, { FC, useContext } from 'react';
 
 import { md } from 'common/components/Markdown';
+import { UserProfileContext } from 'profile/providers/UserProfile';
 import { Page, Pane } from 'common/components/Panes';
 
 import { Transactions } from 'payments/components/Transactions';
-import { CreateTransaction } from 'payments/components/Transactions/CreateTransaction';
 import { Purchases } from 'payments/components/Transactions/Purchases';
-
-const ABOUT_TRANSACTIONS = md`
-  # Transaksjoner
-
-  Transaksjoner er innskuddene du har gjort til saldo hos Online.
-  Dette er pengene du kan bruke i kiosken (Nibble) på Onlinekontoret.
-`;
-
 export const Wallet: FC = () => {
+  const { user } = useContext(UserProfileContext);
+
+  const ABOUT_TRANSACTIONS = md`
+# Vi bruker nå vipps i kiosken! 🔥
+Nå har vi endelig gått over til ny betalingsløsning i kiosken hvor man betaler ved Vipps!
+
+**Hvordan betaler jeg?** 😎
+
+Scan qr koden i kiosken eller på kjøleskapet, velg produkter og betal med Vipps. Første gangen du kjøper noe må du verifisere Vipps før du betaler, så dobbeltsjekk at Vipps-betalingen går gjennom.
+
+**Men jeg har fortsatt penger på studentkortet mitt** 😱
+
+Frykt ikke! Vi vil ha en overgangsperiode på 2 måneder, så dere har god tid på å bruke opp saldoen deres!
+
+Send melding til Johanna Wilmers på slack hvis det er noen spørsmål/problemer
+
+## Gjennværende saldo: **${String(!!user ? user.saldo : 0)} kr**
+  `;
+
   return (
     <Page>
       <Pane>{ABOUT_TRANSACTIONS}</Pane>
-      <CreateTransaction />
       <Transactions />
       <Purchases />
     </Page>


### PR DESCRIPTION
Tenker dette er greit ihvertfall i overgangsperioden på 2 måneder? Så kan man evt fjerne saldo-siden helt etter den

Før:
<img width="1186" alt="image" src="https://github.com/dotkom/onlineweb-frontend/assets/55615149/ed0d123f-10f7-4e9c-9e27-f0da963ff179">


Etter:
<img width="1026" alt="image" src="https://github.com/dotkom/onlineweb-frontend/assets/55615149/94102f8d-e758-45f6-af99-9f42b17e0b52">
