### PR TITLE
minimize requests to backend from frontend on event page DOT-262

### DIFF
--- a/src/events/components/DetailView/index.tsx
+++ b/src/events/components/DetailView/index.tsx
@@ -1,32 +1,94 @@
+import React from 'react';
 import Head from 'next/head';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import Spinner from 'common/components/Spinner';
 import { DOMAIN } from 'common/constants/endpoints';
 import HttpError from 'core/components/errors/HttpError';
 import { useDispatch, useSelector } from 'core/redux/hooks';
-import { fetchAttendanceEventById } from 'events/slices/attendanceEvents';
-import { eventSelectors, fetchEventById } from 'events/slices/events';
+import { fetchAttendanceEventById, setAttendanceEventFromLocalStorage } from 'events/slices/attendanceEvents';
+import { fetchEventById, setEventFromLocalStorage } from 'events/slices/events';
 
+import { IAttendanceEvent, IEvent } from 'events/models/Event';
 import Contact from './Contact';
-import style from './detail.less';
 import InfoBox from './InfoBox';
 import PictureCard from './PictureCard';
 import Registration from './Registation';
+import style from './detail.less';
 
 interface IProps {
   eventId: number;
 }
 
+export const getAttendanceEventLSKey = (eventId: number) => `attendanceevent-${eventId}`;
+export const getEventLSKey = (eventId: number) => `event-${eventId}`;
+
+export interface ObjectInLocalStorage<T> {
+  validTo: number;
+  data: T;
+}
+
+const useFetchEvent = (eventId: number) => {
+  const dispatch = useDispatch();
+  // see if event in localStorage
+  const eventStr = localStorage.getItem(getEventLSKey(eventId));
+  let event: ObjectInLocalStorage<IEvent> | null = null;
+
+  useEffect(() => {
+    if (!eventStr) {
+      dispatch(fetchEventById(eventId));
+    } else {
+      if (eventStr) {
+        event = JSON.parse(eventStr) as ObjectInLocalStorage<IEvent>;
+
+        if (event.validTo < Date.now()) {
+          dispatch(fetchEventById(eventId));
+          return;
+        }
+
+        dispatch(setEventFromLocalStorage(event.data));
+      }
+    }
+  }, [eventId, dispatch]);
+
+  return event;
+};
+
+const useFetchAttendanceEvent = (eventId: number) => {
+  const dispatch = useDispatch();
+  // see if event in localStorage
+  const eventStr = localStorage.getItem(getAttendanceEventLSKey(eventId));
+  let event: ObjectInLocalStorage<IAttendanceEvent> | null = null;
+
+  useEffect(() => {
+    if (!eventStr) {
+      dispatch(fetchAttendanceEventById(eventId));
+    } else {
+      if (eventStr) {
+        event = JSON.parse(eventStr) as ObjectInLocalStorage<IAttendanceEvent>;
+
+        if (event.validTo < Date.now()) {
+          dispatch(fetchAttendanceEventById(eventId));
+          return;
+        }
+
+        dispatch(setAttendanceEventFromLocalStorage(event.data));
+      }
+    }
+  }, [eventId, dispatch]);
+  return event;
+};
+
 export const DetailView = ({ eventId }: IProps) => {
   const dispatch = useDispatch();
-  const event = useSelector((state) => eventSelectors.selectById(state, eventId));
+  const event = useSelector((state) => state.events.entities[eventId]);
   const isPending = useSelector((state) => state.events.loading === 'pending');
+
+  useFetchEvent(eventId);
+  useFetchAttendanceEvent(eventId);
 
   useEffect(() => {
     window.scrollTo(0, 0);
-    dispatch(fetchEventById(eventId));
-    dispatch(fetchAttendanceEventById(eventId));
   }, [eventId, dispatch]);
 
   if (isPending && !event) {

--- a/src/events/components/DetailView/index.tsx
+++ b/src/events/components/DetailView/index.tsx
@@ -13,7 +13,6 @@ import style from './detail.less';
 import InfoBox from './InfoBox';
 import PictureCard from './PictureCard';
 import Registration from './Registation';
-import { selectIsLoggedIn } from 'authentication/selectors/authentication';
 
 interface IProps {
   eventId: number;
@@ -23,13 +22,12 @@ export const DetailView = ({ eventId }: IProps) => {
   const dispatch = useDispatch();
   const event = useSelector((state) => eventSelectors.selectById(state, eventId));
   const isPending = useSelector((state) => state.events.loading === 'pending');
-  const isLoggedIn = useSelector(selectIsLoggedIn());
 
   useEffect(() => {
     window.scrollTo(0, 0);
     dispatch(fetchEventById(eventId));
     dispatch(fetchAttendanceEventById(eventId));
-  }, [eventId, dispatch, isLoggedIn]);
+  }, [eventId, dispatch]);
 
   if (isPending && !event) {
     return <Spinner />;


### PR DESCRIPTION
The queries made to the backend from online.ntnu.no/events/{event} are expensive. To avoid that the backend crashes on big events, we want to be smart about how many requests we send from the frontend.

### Measures
**Double fetching bug**
Prev behaviour: User goes to the event detail page. Event/attendance event data is fetched from backend. This is done in a useEffect with userLoggedIn as dep. This causes useEffect to be ran twice, as isLoggedIn goes from false on init to true. 

Now: event data is fetched from the backend once independent of user being logged in or not. For the user, there is no difference as to before.

**Caching backend response when fresh content is not needed**
