### PR TITLE
Randomize committee ordering every hour and removed outdated links

### DIFF
--- a/src/pages/applications/index.tsx
+++ b/src/pages/applications/index.tsx
@@ -15,7 +15,7 @@ const getHourlyUpdatedSortKey = (key: string) => {
 
 const Committees: React.FC = () => {
   const [committees, setCommittees] = useState<IOnlineGroup[]>([]);
-  const applicationFormUrl = 'https://forms.gle/BpQfh42FXfC85tNd6'; // updated for August 2023
+  // const applicationFormUrl = 'https://forms.gle/BpQfh42FXfC85tNd6'; // updated for August 2023
 
   useEffect(() => {
     console.log('Running');

--- a/src/pages/applications/index.tsx
+++ b/src/pages/applications/index.tsx
@@ -6,6 +6,13 @@ import React, { useEffect, useState } from 'react';
 import style from '../../applications/committee.less';
 import crypto from 'crypto';
 
+const getHourlyUpdatedSortKey = (key: string) => {
+    const hash = crypto.createHash('sha256');
+    const hour = Math.floor((+new Date()) / 3600000);
+    hash.update(key + hour.toString());
+    return hash.digest('hex');
+}
+
 const Committees: React.FC = () => {
   const [committees, setCommittees] = useState<IOnlineGroup[]>([]);
   const applicationFormUrl = 'https://forms.gle/BpQfh42FXfC85tNd6'; // updated for August 2023
@@ -22,17 +29,10 @@ const Committees: React.FC = () => {
         ) {
           CommitteeList.push(groups[i]);
         }
-      }
-
-      const getKey = (key: string) => {
-        const hash = crypto.createHash('sha256');
-        const hour = Math.floor((+new Date()) / 3600000);
-        hash.update(key + hour.toString());
-        return hash.digest('hex');
-      }
+      } 
 
       CommitteeList.sort((a, b) => {
-        return getKey(a.name_short) > getKey(b.name_short) ? 1 : -1;
+        return getHourlyUpdatedSortKey(a.name_short) > getHourlyUpdatedSortKey(b.name_short) ? 1 : -1;
       });
       setCommittees(CommitteeList);
     });

--- a/src/pages/applications/index.tsx
+++ b/src/pages/applications/index.tsx
@@ -17,7 +17,7 @@ const getHourlyUpdatedSortKey = (key: string) => {
 
 const Committees: React.FC = () => {
   const [committees, setCommittees] = useState<IOnlineGroup[]>([]);
-  // const applicationFormUrl = 'https://forms.gle/BpQfh42FXfC85tNd6'; // updated for August 2023
+  const applicationFormUrl = 'https://forms.gle/BpQfh42FXfC85tNd6'; // updated for August 2023
 
   useEffect(() => {
     console.log('Running');

--- a/src/pages/applications/index.tsx
+++ b/src/pages/applications/index.tsx
@@ -13,8 +13,6 @@ const getHourlyUpdatedSortKey = (key: string) => {
     return hash.digest('hex');
 }
 
-// test
-
 const Committees: React.FC = () => {
   const [committees, setCommittees] = useState<IOnlineGroup[]>([]);
   const applicationFormUrl = 'https://forms.gle/BpQfh42FXfC85tNd6'; // updated for August 2023

--- a/src/pages/applications/index.tsx
+++ b/src/pages/applications/index.tsx
@@ -13,6 +13,8 @@ const getHourlyUpdatedSortKey = (key: string) => {
     return hash.digest('hex');
 }
 
+// test
+
 const Committees: React.FC = () => {
   const [committees, setCommittees] = useState<IOnlineGroup[]>([]);
   // const applicationFormUrl = 'https://forms.gle/BpQfh42FXfC85tNd6'; // updated for August 2023

--- a/src/pages/applications/index.tsx
+++ b/src/pages/applications/index.tsx
@@ -4,6 +4,7 @@ import { IOnlineGroup } from 'groups/models/onlinegroup';
 import React, { useEffect, useState } from 'react';
 
 import style from '../../applications/committee.less';
+import crypto from 'crypto';
 
 const Committees: React.FC = () => {
   const [committees, setCommittees] = useState<IOnlineGroup[]>([]);
@@ -22,6 +23,17 @@ const Committees: React.FC = () => {
           CommitteeList.push(groups[i]);
         }
       }
+
+      const getKey = (key: string) => {
+        const hash = crypto.createHash('sha256');
+        const hour = Math.floor((+new Date()) / 3600000);
+        hash.update(key + hour.toString());
+        return hash.digest('hex');
+      }
+
+      CommitteeList.sort((a, b) => {
+        return getKey(a.name_short) > getKey(b.name_short) ? 1 : -1;
+      });
       setCommittees(CommitteeList);
     });
   }, []);
@@ -31,7 +43,7 @@ const Committees: React.FC = () => {
       <div className={style.intro}>
         Komitémedlemmene våre får Online til å gå rundt, og arbeider for at alle informatikkstudenter skal ha en flott
         studiehverdag.
-        <br /> <a href={applicationFormUrl}>Her</a> kan du søke om å bli en av oss!
+        {/* <br /> <a href={applicationFormUrl}>Her</a> kan du søke om å bli en av oss! */ }
       </div>
       {committees.map((com) => {
         return (
@@ -42,11 +54,13 @@ const Committees: React.FC = () => {
           </div>
         );
       })}
+      {/*
       <div className={style.applyButton}>
         <a className={style.apply} href={applicationFormUrl}>
           Trykk her for å sende inn en søknad!
         </a>
       </div>
+      */}
     </div>
   );
 };


### PR DESCRIPTION
Currently the committees are alphabetically ordered which means most people will only read the first few, this makes that fair. 