### PR TITLE
Rolling admission message

### DIFF
--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -71,10 +71,10 @@ const JobDetails: FC<IProps> = ({ opportunity }) => (
             <h3>Nøkkelinformasjon</h3>
             <p>Type: {opportunity.employment.name}</p>
             <p>Sted: {formatLocations(opportunity.location.map((loc) => loc.name))}</p>
-            <p>Frist: {opportunity.deadline_asap ? 'Snarest' : formatDeadline(opportunity.deadline)}</p>
+            {opportunity.deadline && <p>Frist: {formatDeadline(opportunity.deadline)}</p>}
             {opportunity.rolling_admission && (
               <p>
-                <strong>Fortløpende opptak: Ja</strong>
+                <strong>Fortløpende opptak</strong>
               </p>
             )}
           </div>

--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -72,6 +72,11 @@ const JobDetails: FC<IProps> = ({ opportunity }) => (
             <p>Type: {opportunity.employment.name}</p>
             <p>Sted: {formatLocations(opportunity.location.map((loc) => loc.name))}</p>
             <p>Frist: {opportunity.deadline_asap ? 'Snarest' : formatDeadline(opportunity.deadline)}</p>
+            {opportunity.rolling_admission && (
+              <p>
+                <strong>Fortløpende opptak: Ja</strong>
+              </p>
+            )}
           </div>
           <ApplyButton
             application_link={opportunity.application_link}

--- a/src/career/components/JobDetails.tsx
+++ b/src/career/components/JobDetails.tsx
@@ -74,7 +74,7 @@ const JobDetails: FC<IProps> = ({ opportunity }) => (
             {opportunity.deadline && <p>Frist: {formatDeadline(opportunity.deadline)}</p>}
             {opportunity.rolling_admission && (
               <p>
-                <strong>Fortløpende opptak</strong>
+                <strong>Søknader vurderes fortløpende</strong>
               </p>
             )}
           </div>

--- a/src/career/models/Career.ts
+++ b/src/career/models/Career.ts
@@ -10,7 +10,6 @@ export interface ICareerOpportunity {
   end: string;
   featured: boolean;
   deadline: string;
-  deadline_asap: boolean;
   rolling_admission: boolean;
   employment: IEmployment;
   location: ILocation[];

--- a/src/career/models/Career.ts
+++ b/src/career/models/Career.ts
@@ -11,6 +11,7 @@ export interface ICareerOpportunity {
   featured: boolean;
   deadline: string;
   deadline_asap: boolean;
+  rolling_admission: boolean;
   employment: IEmployment;
   location: ILocation[];
   application_link: string;


### PR DESCRIPTION
https://github.com/dotkom/onlineweb4/pull/3300

![image](https://github.com/user-attachments/assets/dcabb3d1-fc13-4761-8d26-facb700ada9a)

Tanken med **bold** er å prøve å oppmerksomheten bort til teksten iom. at folk er vant til at det ikke står noe ny informasjon der, og at det er noe som kan tas bort etterhvert som folk lærer at det står der. Kan godt droppe det hvis noen har sterke meninger imot. 